### PR TITLE
HADOOP-16010. Replace the url of the repository in Apache Hadoop site.

### DIFF
--- a/content/index.xml
+++ b/content/index.xml
@@ -1222,7 +1222,7 @@ Security The security mailing list is a private list for discussion of potential
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://hadoop.apache.org/version_control.html</guid>
-      <description>Overview The Hadoop source code resides in the Apache git repository, and available from here: https://git-wip-us.apache.org/repos/asf?p=hadoop.git
+      <description>Overview The Hadoop source code resides in the Apache git repository, and available from here: https://gitbox.apache.org/repos/asf?p=hadoop.git
 The changes are also mirrored to the github repository https://github.com/apache/hadoop
 Hdfs, Yarn, Mapreduce and other components all are parts of this one repository.</description>
     </item>

--- a/content/version_control.html
+++ b/content/version_control.html
@@ -167,7 +167,7 @@
 <h2 id="overview">Overview</h2>
 
 <p>The Hadoop source code resides in the Apache git repository, and available from here:
-<a href="https://git-wip-us.apache.org/repos/asf?p=hadoop.git">https://git-wip-us.apache.org/repos/asf?p=hadoop.git</a></p>
+<a href="https://gitbox.apache.org/repos/asf?p=hadoop.git">https://gitbox.apache.org/repos/asf?p=hadoop.git</a></p>
 
 <p>The changes are also mirrored to the github repository <a href="https://github.com/apache/hadoop">https://github.com/apache/hadoop</a></p>
 

--- a/src/version_control.md
+++ b/src/version_control.md
@@ -22,7 +22,7 @@ menu:
 ## Overview
 
 The Hadoop source code resides in the Apache git repository, and available from here:
-https://git-wip-us.apache.org/repos/asf?p=hadoop.git
+https://gitbox.apache.org/repos/asf?p=hadoop.git
 
 The changes are also mirrored to the github repository https://github.com/apache/hadoop
 


### PR DESCRIPTION
DO NOT merge this until the migration is completed.
JIRA: https://issues.apache.org/jira/browse/HADOOP-16010