### PR TITLE
HADOOP-16514. Current/stable documentation should link to Hadoop 3.

### DIFF
--- a/content/docs/current
+++ b/content/docs/current
@@ -1,1 +1,1 @@
-current2
+current3

--- a/content/docs/stable
+++ b/content/docs/stable
@@ -1,1 +1,1 @@
-stable2
+stable3


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-16514

* current -> current3 -> 3.2.0
* stable -> stable3 -> 3.2.0