### PR TITLE
HADOOP-16550. Spark config name error on the Launching Applications Using Docker Containers page

### DIFF
--- a/content/docs/r2.8.2/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r2.8.2/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -683,8 +683,8 @@
 <div class="source">
 <pre>    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>
       </div>

--- a/content/docs/r2.8.3/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r2.8.3/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -684,8 +684,8 @@
 <div class="source">
 <pre>    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>
       </div>

--- a/content/docs/r2.8.4/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r2.8.4/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -684,8 +684,8 @@
 <div class="source">
 <pre>    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>
       </div>

--- a/content/docs/r2.8.5/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r2.8.5/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -684,8 +684,8 @@
 <div class="source">
 <pre>    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>
       </div>

--- a/content/docs/r2.9.0/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r2.9.0/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -807,8 +807,8 @@
 <div class="source">
 <pre>    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>
       </div>

--- a/content/docs/r2.9.1/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r2.9.1/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -819,8 +819,8 @@
 <div class="source">
 <pre>    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>
       </div>

--- a/content/docs/r2.9.2/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r2.9.2/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -819,8 +819,8 @@
 <div class="source">
 <pre>    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>
       </div>

--- a/content/docs/r3.0.0/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r3.0.0/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -744,8 +744,8 @@
 <div>
 <pre class="source">    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>

--- a/content/docs/r3.0.1/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r3.0.1/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -756,8 +756,8 @@
 <div>
 <pre class="source">    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>

--- a/content/docs/r3.0.2/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r3.0.2/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -756,8 +756,8 @@
 <div>
 <pre class="source">    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>

--- a/content/docs/r3.0.3/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r3.0.3/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -759,8 +759,8 @@
 <div>
 <pre class="source">    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>

--- a/content/docs/r3.1.0/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r3.1.0/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -830,8 +830,8 @@
 <div>
 <pre class="source">    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>

--- a/content/docs/r3.1.1/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
+++ b/content/docs/r3.1.1/hadoop-yarn/hadoop-yarn-site/DockerContainers.html
@@ -859,8 +859,8 @@
 <div>
 <pre class="source">    spark-shell --master yarn --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_TYPE=docker \
         --conf spark.executorEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
-        --conf spark.yarn.AppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE=hadoop-docker \
+        --conf spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE=docker
 </pre></div></div>
 
 <p>Note that the application master and executors are configured independently. In this example, we are using the hadoop-docker image for both.</p></div>


### PR DESCRIPTION
On the "Launching Applications Using Docker Containers" page at the "Example: Spark" section the Spark config for configuring the environment variables for the application master the config prefix are wrong:
- spark.yarn.**A**ppMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE
- spark.yarn.**A**ppMasterEnv.YARN_CONTAINER_RUNTIME_TYPE

The correct ones:
- spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_DOCKER_IMAGE
- spark.yarn.appMasterEnv.YARN_CONTAINER_RUNTIME_TYPE

See https://spark.apache.org/docs/2.4.0/running-on-yarn.html:

> spark.yarn.appMasterEnv.[EnvironmentVariableName]