### PR TITLE
Fix typo in MapReduce output

### DIFF
--- a/content/docs/r2.5.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.5.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1035,7 +1035,7 @@ public class WordCount2 {
 <p>Run it once more, this time switch-off case-sensitivity:</p>
 <p><tt>$ bin/hadoop jar wc.jar WordCount2 -Dwordcount.case.sensitive=false /user/joe/wordcount/input /user/joe/wordcount/output -skip /user/joe/wordcount/patterns.txt</tt></p>
 <p>Sure enough, the output:</p>
-<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>horld 2</tt></p></div>
+<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>world 2</tt></p></div>
 <div class="section">
 <h5>Highlights<a name="Highlights"></a></h5>
 <p>The second version of <tt>WordCount</tt> improves upon the previous one by using some features offered by the MapReduce framework:</p>

--- a/content/docs/r2.6.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.6.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1062,7 +1062,7 @@ public class WordCount2 {
 <p>Run it once more, this time switch-off case-sensitivity:</p>
 <p><tt>$ bin/hadoop jar wc.jar WordCount2 -Dwordcount.case.sensitive=false /user/joe/wordcount/input /user/joe/wordcount/output -skip /user/joe/wordcount/patterns.txt</tt></p>
 <p>Sure enough, the output:</p>
-<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>horld 2</tt></p></div>
+<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>world 2</tt></p></div>
 <div class="section">
 <h5>Highlights<a name="Highlights"></a></h5>
 <p>The second version of <tt>WordCount</tt> improves upon the previous one by using some features offered by the MapReduce framework:</p>

--- a/content/docs/r2.6.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.6.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1062,7 +1062,7 @@ public class WordCount2 {
 <p>Run it once more, this time switch-off case-sensitivity:</p>
 <p><tt>$ bin/hadoop jar wc.jar WordCount2 -Dwordcount.case.sensitive=false /user/joe/wordcount/input /user/joe/wordcount/output -skip /user/joe/wordcount/patterns.txt</tt></p>
 <p>Sure enough, the output:</p>
-<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>horld 2</tt></p></div>
+<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>world 2</tt></p></div>
 <div class="section">
 <h5>Highlights<a name="Highlights"></a></h5>
 <p>The second version of <tt>WordCount</tt> improves upon the previous one by using some features offered by the MapReduce framework:</p>

--- a/content/docs/r2.6.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.6.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1062,7 +1062,7 @@ public class WordCount2 {
 <p>Run it once more, this time switch-off case-sensitivity:</p>
 <p><tt>$ bin/hadoop jar wc.jar WordCount2 -Dwordcount.case.sensitive=false /user/joe/wordcount/input /user/joe/wordcount/output -skip /user/joe/wordcount/patterns.txt</tt></p>
 <p>Sure enough, the output:</p>
-<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>horld 2</tt></p></div>
+<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>world 2</tt></p></div>
 <div class="section">
 <h5>Highlights<a name="Highlights"></a></h5>
 <p>The second version of <tt>WordCount</tt> improves upon the previous one by using some features offered by the MapReduce framework:</p>

--- a/content/docs/r2.6.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.6.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1062,7 +1062,7 @@ public class WordCount2 {
 <p>Run it once more, this time switch-off case-sensitivity:</p>
 <p><tt>$ bin/hadoop jar wc.jar WordCount2 -Dwordcount.case.sensitive=false /user/joe/wordcount/input /user/joe/wordcount/output -skip /user/joe/wordcount/patterns.txt</tt></p>
 <p>Sure enough, the output:</p>
-<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>horld 2</tt></p></div>
+<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>world 2</tt></p></div>
 <div class="section">
 <h5>Highlights<a name="Highlights"></a></h5>
 <p>The second version of <tt>WordCount</tt> improves upon the previous one by using some features offered by the MapReduce framework:</p>

--- a/content/docs/r2.6.4/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.6.4/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1062,7 +1062,7 @@ public class WordCount2 {
 <p>Run it once more, this time switch-off case-sensitivity:</p>
 <p><tt>$ bin/hadoop jar wc.jar WordCount2 -Dwordcount.case.sensitive=false /user/joe/wordcount/input /user/joe/wordcount/output -skip /user/joe/wordcount/patterns.txt</tt></p>
 <p>Sure enough, the output:</p>
-<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>horld 2</tt></p></div>
+<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>world 2</tt></p></div>
 <div class="section">
 <h5>Highlights<a name="Highlights"></a></h5>
 <p>The second version of <tt>WordCount</tt> improves upon the previous one by using some features offered by the MapReduce framework:</p>

--- a/content/docs/r2.6.5/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.6.5/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1062,7 +1062,7 @@ public class WordCount2 {
 <p>Run it once more, this time switch-off case-sensitivity:</p>
 <p><tt>$ bin/hadoop jar wc.jar WordCount2 -Dwordcount.case.sensitive=false /user/joe/wordcount/input /user/joe/wordcount/output -skip /user/joe/wordcount/patterns.txt</tt></p>
 <p>Sure enough, the output:</p>
-<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>horld 2</tt></p></div>
+<p><tt>$ bin/hdfs dfs -cat /user/joe/wordcount/output/part-r-00000</tt> <br /><tt>bye 1</tt> <br /><tt>goodbye 1</tt> <br /><tt>hadoop 2</tt> <br /><tt>hello 2</tt> <br /><tt>world 2</tt></p></div>
 <div class="section">
 <h5>Highlights<a name="Highlights"></a></h5>
 <p>The second version of <tt>WordCount</tt> improves upon the previous one by using some features offered by the MapReduce framework:</p>

--- a/content/docs/r2.7.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.7.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1547,7 +1547,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.7.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.7.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1553,7 +1553,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.7.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.7.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1556,7 +1556,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.7.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.7.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1559,7 +1559,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.7.4/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.7.4/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1559,7 +1559,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.7.5/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.7.5/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1559,7 +1559,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.7.6/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.7.6/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1559,7 +1559,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.7.7/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.7.7/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1559,7 +1559,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.8.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.8.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1564,7 +1564,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.8.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.8.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1567,7 +1567,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.8.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.8.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1567,7 +1567,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.8.4/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.8.4/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1567,7 +1567,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.8.5/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.8.5/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1567,7 +1567,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.9.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.9.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1533,7 +1533,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.9.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.9.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1533,7 +1533,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r2.9.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r2.9.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1533,7 +1533,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div></div>
 <div class="section">
 <h4><a name="Highlights"></a>Highlights</h4>

--- a/content/docs/r3.0.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.0.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1503,7 +1503,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">

--- a/content/docs/r3.0.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.0.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1503,7 +1503,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">

--- a/content/docs/r3.0.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.0.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1503,7 +1503,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">

--- a/content/docs/r3.0.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.0.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1506,7 +1506,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">

--- a/content/docs/r3.1.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.1.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1527,7 +1527,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">

--- a/content/docs/r3.1.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.1.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1542,7 +1542,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">

--- a/content/docs/r3.1.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.1.2/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1542,7 +1542,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">

--- a/content/docs/r3.1.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.1.3/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1542,7 +1542,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">

--- a/content/docs/r3.2.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.2.0/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1565,7 +1565,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">

--- a/content/docs/r3.2.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
+++ b/content/docs/r3.2.1/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html
@@ -1568,7 +1568,7 @@ bye 1
 goodbye 1
 hadoop 2
 hello 2
-horld 2
+world 2
 </pre></div></div>
 </div>
 <div class="section">


### PR DESCRIPTION
There's a mismatch in outputs on the [page](https://hadoop.apache.org/docs/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core/MapReduceTutorial.html)

<img width="353" alt="Screenshot 2019-11-04 at 23 26 44" src="https://user-images.githubusercontent.com/10631410/68159611-c93f0200-ff5a-11e9-9fe2-efa3e786fb22.png">
