### PR TITLE
HADOOP-16714. Hadoop website does not mention 2.8.5 release.

### DIFF
--- a/content/bylaws.html
+++ b/content/bylaws.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/categories.html
+++ b/content/categories.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/categories/index.xml
+++ b/content/categories/index.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Categories on Apache Hadoop</title>

--- a/content/committer_criteria.html
+++ b/content/committer_criteria.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/cve_list.html
+++ b/content/cve_list.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/description.html
+++ b/content/description.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/index.html
+++ b/content/index.html
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-	<meta name="generator" content="Hugo 0.59.0" />
+	<meta name="generator" content="Hugo 0.58.3" />
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -69,6 +69,8 @@
                <li><a href="https://hadoop.apache.org/docs/r3.1.2/">3.1.2</a></li>
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
+               
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
                
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>

--- a/content/index.xml
+++ b/content/index.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Apache Hadoop</title>

--- a/content/issue_tracking.html
+++ b/content/issue_tracking.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/mailing_lists.html
+++ b/content/mailing_lists.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/modules.html
+++ b/content/modules.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news.html
+++ b/content/news.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2008-07-xx-terabyte-sort.html
+++ b/content/news/2008-07-xx-terabyte-sort.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2008-11-xx-apachecon.html
+++ b/content/news/2008-11-xx-apachecon.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2009-03-xx-apachecon-eu.html
+++ b/content/news/2009-03-xx-apachecon-eu.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2009-07-xx-subprojects.html
+++ b/content/news/2009-07-xx-subprojects.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2010-05-xx-avro-hbase.html
+++ b/content/news/2010-05-xx-avro-hbase.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2010-10-xx-hive-pig.html
+++ b/content/news/2010-10-xx-hive-pig.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2011-01-xx-zookeeper.html
+++ b/content/news/2011-01-xx-zookeeper.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2011-03-xx-award.html
+++ b/content/news/2011-03-xx-award.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2018-10-01-ozone-0.2.1-alpha.html
+++ b/content/news/2018-10-01-ozone-0.2.1-alpha.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2018-11-22-ozone-0.3.0-alpha.html
+++ b/content/news/2018-11-22-ozone-0.3.0-alpha.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2019-05-07-ozone-0.4.0-alpha.html
+++ b/content/news/2019-05-07-ozone-0.4.0-alpha.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2019-10-13-ozone-0.4.1-alpha.html
+++ b/content/news/2019-10-13-ozone-0.4.1-alpha.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/index.xml
+++ b/content/news/index.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>News on Apache Hadoop</title>

--- a/content/news/page/2.html
+++ b/content/news/page/2.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/privacy_policy.html
+++ b/content/privacy_policy.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/related.html
+++ b/content/related.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release.html
+++ b/content/release.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.14.1.html
+++ b/content/release/0.14.1.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.14.3.html
+++ b/content/release/0.14.3.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.14.4.html
+++ b/content/release/0.14.4.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.15.0.html
+++ b/content/release/0.15.0.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.15.1.html
+++ b/content/release/0.15.1.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.15.2.html
+++ b/content/release/0.15.2.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.15.3.html
+++ b/content/release/0.15.3.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.0.html
+++ b/content/release/0.16.0.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.1.html
+++ b/content/release/0.16.1.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.2.html
+++ b/content/release/0.16.2.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.3.html
+++ b/content/release/0.16.3.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.4.html
+++ b/content/release/0.16.4.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.17.0.html
+++ b/content/release/0.17.0.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.17.1.html
+++ b/content/release/0.17.1.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.17.2.html
+++ b/content/release/0.17.2.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.18.0.html
+++ b/content/release/0.18.0.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.18.1.html
+++ b/content/release/0.18.1.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.18.2.html
+++ b/content/release/0.18.2.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.18.3.html
+++ b/content/release/0.18.3.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.19.0.html
+++ b/content/release/0.19.0.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.19.1.html
+++ b/content/release/0.19.1.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.19.2.html
+++ b/content/release/0.19.2.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.0.html
+++ b/content/release/0.20.0.html
@@ -80,6 +80,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.1.html
+++ b/content/release/0.20.1.html
@@ -80,6 +80,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.2.html
+++ b/content/release/0.20.2.html
@@ -80,6 +80,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.203.0.html
+++ b/content/release/0.20.203.0.html
@@ -82,6 +82,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.204.0.html
+++ b/content/release/0.20.204.0.html
@@ -82,6 +82,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.205.0.html
+++ b/content/release/0.20.205.0.html
@@ -82,6 +82,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.21.0.html
+++ b/content/release/0.21.0.html
@@ -78,6 +78,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.22.0.html
+++ b/content/release/0.22.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.0.html
+++ b/content/release/0.23.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.1.html
+++ b/content/release/0.23.1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.10.html
+++ b/content/release/0.23.10.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.11.html
+++ b/content/release/0.23.11.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.3.html
+++ b/content/release/0.23.3.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.4.html
+++ b/content/release/0.23.4.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.5.html
+++ b/content/release/0.23.5.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.6.html
+++ b/content/release/0.23.6.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.7.html
+++ b/content/release/0.23.7.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.8.html
+++ b/content/release/0.23.8.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.9.html
+++ b/content/release/0.23.9.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.0.html
+++ b/content/release/1.0.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.1.html
+++ b/content/release/1.0.1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.2.html
+++ b/content/release/1.0.2.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.3.html
+++ b/content/release/1.0.3.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.4.html
+++ b/content/release/1.0.4.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.1.0.html
+++ b/content/release/1.1.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.1.1.html
+++ b/content/release/1.1.1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.1.2.html
+++ b/content/release/1.1.2.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.2.0.html
+++ b/content/release/1.2.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.2.1.html
+++ b/content/release/1.2.1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.0-alpha.html
+++ b/content/release/2.0.0-alpha.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.1-alpha.html
+++ b/content/release/2.0.1-alpha.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.2-alpha.html
+++ b/content/release/2.0.2-alpha.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.3-alpha.html
+++ b/content/release/2.0.3-alpha.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.4-alpha.html
+++ b/content/release/2.0.4-alpha.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.5-alpha.html
+++ b/content/release/2.0.5-alpha.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.6-alpha.html
+++ b/content/release/2.0.6-alpha.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.1.0-beta.html
+++ b/content/release/2.1.0-beta.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.1.1-beta.html
+++ b/content/release/2.1.1-beta.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.10.0.html
+++ b/content/release/2.10.0.html
@@ -83,6 +83,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.2.0.html
+++ b/content/release/2.2.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.3.0.html
+++ b/content/release/2.3.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.4.0.html
+++ b/content/release/2.4.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.4.1.html
+++ b/content/release/2.4.1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.5.0.html
+++ b/content/release/2.5.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.5.1.html
+++ b/content/release/2.5.1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.5.2.html
+++ b/content/release/2.5.2.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.0.html
+++ b/content/release/2.6.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.1.html
+++ b/content/release/2.6.1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.2.html
+++ b/content/release/2.6.2.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.3.html
+++ b/content/release/2.6.3.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.4.html
+++ b/content/release/2.6.4.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.5.html
+++ b/content/release/2.6.5.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.0.html
+++ b/content/release/2.7.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.1.html
+++ b/content/release/2.7.1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.2.html
+++ b/content/release/2.7.2.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.3.html
+++ b/content/release/2.7.3.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.4.html
+++ b/content/release/2.7.4.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.5.html
+++ b/content/release/2.7.5.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.6.html
+++ b/content/release/2.7.6.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.7.html
+++ b/content/release/2.7.7.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.0.html
+++ b/content/release/2.8.0.html
@@ -84,6 +84,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.1.html
+++ b/content/release/2.8.1.html
@@ -84,6 +84,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.2.html
+++ b/content/release/2.8.2.html
@@ -84,6 +84,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.3.html
+++ b/content/release/2.8.3.html
@@ -84,6 +84,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.4.html
+++ b/content/release/2.8.4.html
@@ -84,6 +84,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.5.html
+++ b/content/release/2.8.5.html
@@ -84,6 +84,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.9.0.html
+++ b/content/release/2.9.0.html
@@ -83,6 +83,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.9.1.html
+++ b/content/release/2.9.1.html
@@ -83,6 +83,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.9.2.html
+++ b/content/release/2.9.2.html
@@ -83,6 +83,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0-alpha1.html
+++ b/content/release/3.0.0-alpha1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0-alpha2.html
+++ b/content/release/3.0.0-alpha2.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0-alpha4.html
+++ b/content/release/3.0.0-alpha4.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0-beta1.html
+++ b/content/release/3.0.0-beta1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0.html
+++ b/content/release/3.0.0.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.1.html
+++ b/content/release/3.0.1.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.2.html
+++ b/content/release/3.0.2.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.3.html
+++ b/content/release/3.0.3.html
@@ -81,6 +81,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.1.0.html
+++ b/content/release/3.1.0.html
@@ -83,6 +83,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.1.1.html
+++ b/content/release/3.1.1.html
@@ -83,6 +83,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.1.2.html
+++ b/content/release/3.1.2.html
@@ -83,6 +83,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.1.3.html
+++ b/content/release/3.1.3.html
@@ -85,6 +85,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.2.0.html
+++ b/content/release/3.2.0.html
@@ -83,6 +83,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.2.1.html
+++ b/content/release/3.2.1.html
@@ -85,6 +85,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/index.xml
+++ b/content/release/index.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Releases on Apache Hadoop</title>

--- a/content/release/page/10.html
+++ b/content/release/page/10.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/11.html
+++ b/content/release/page/11.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/2.html
+++ b/content/release/page/2.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/3.html
+++ b/content/release/page/3.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/4.html
+++ b/content/release/page/4.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/5.html
+++ b/content/release/page/5.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/6.html
+++ b/content/release/page/6.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/7.html
+++ b/content/release/page/7.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/8.html
+++ b/content/release/page/8.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/9.html
+++ b/content/release/page/9.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/releases.html
+++ b/content/releases.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/sitemap.xml
+++ b/content/sitemap.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   

--- a/content/tags.html
+++ b/content/tags.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/tags/index.xml
+++ b/content/tags/index.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Tags on Apache Hadoop</title>

--- a/content/version_control.html
+++ b/content/version_control.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/versioning.html
+++ b/content/versioning.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/who.html
+++ b/content/who.html
@@ -69,6 +69,8 @@
                
                <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
+               <li><a href="https://hadoop.apache.org/docs/r2.8.5/">2.8.5</a></li>
+               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/src/release/2.8.5.md
+++ b/src/release/2.8.5.md
@@ -1,6 +1,7 @@
 ---
 title: Release 2.8.5 available
 date: 2018-09-15
+linked: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-16714

Add back "linked: true" in src/releases/2.8.5.md.