### PR TITLE
HADOOP-17435. Remove Hadoop 2.9.2 from the download page

### DIFF
--- a/content/bylaws.html
+++ b/content/bylaws.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/categories.html
+++ b/content/categories.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/committer_criteria.html
+++ b/content/committer_criteria.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/cve_list.html
+++ b/content/cve_list.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/description.html
+++ b/content/description.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/index.html
+++ b/content/index.html
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-	<meta name="generator" content="Hugo 0.76.0" />
+	<meta name="generator" content="Hugo 0.75.1" />
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -67,8 +67,6 @@
                <li><a href="https://hadoop.apache.org/docs/r3.3.0/">3.3.0</a></li>
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
-               
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
                
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>

--- a/content/issue_tracking.html
+++ b/content/issue_tracking.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/mailing_lists.html
+++ b/content/mailing_lists.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/modules.html
+++ b/content/modules.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news.html
+++ b/content/news.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2008-07-xx-terabyte-sort.html
+++ b/content/news/2008-07-xx-terabyte-sort.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2008-11-xx-apachecon.html
+++ b/content/news/2008-11-xx-apachecon.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2009-03-xx-apachecon-eu.html
+++ b/content/news/2009-03-xx-apachecon-eu.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2009-07-xx-subprojects.html
+++ b/content/news/2009-07-xx-subprojects.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2010-05-xx-avro-hbase.html
+++ b/content/news/2010-05-xx-avro-hbase.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2010-10-xx-hive-pig.html
+++ b/content/news/2010-10-xx-hive-pig.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2011-01-xx-zookeeper.html
+++ b/content/news/2011-01-xx-zookeeper.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2011-03-xx-award.html
+++ b/content/news/2011-03-xx-award.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2018-10-01-ozone-0.2.1-alpha.html
+++ b/content/news/2018-10-01-ozone-0.2.1-alpha.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2018-11-22-ozone-0.3.0-alpha.html
+++ b/content/news/2018-11-22-ozone-0.3.0-alpha.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2019-05-07-ozone-0.4.0-alpha.html
+++ b/content/news/2019-05-07-ozone-0.4.0-alpha.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2019-10-13-ozone-0.4.1-alpha.html
+++ b/content/news/2019-10-13-ozone-0.4.1-alpha.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2020-03-24-ozone-0.5.0-beta.html
+++ b/content/news/2020-03-24-ozone-0.5.0-beta.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/2020-09-02-ozone-1.0.0.html
+++ b/content/news/2020-09-02-ozone-1.0.0.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/news/page/2.html
+++ b/content/news/page/2.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/privacy_policy.html
+++ b/content/privacy_policy.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/related.html
+++ b/content/related.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release.html
+++ b/content/release.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.14.1.html
+++ b/content/release/0.14.1.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.14.3.html
+++ b/content/release/0.14.3.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.14.4.html
+++ b/content/release/0.14.4.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.15.0.html
+++ b/content/release/0.15.0.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.15.1.html
+++ b/content/release/0.15.1.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.15.2.html
+++ b/content/release/0.15.2.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.15.3.html
+++ b/content/release/0.15.3.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.0.html
+++ b/content/release/0.16.0.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.1.html
+++ b/content/release/0.16.1.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.2.html
+++ b/content/release/0.16.2.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.3.html
+++ b/content/release/0.16.3.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.16.4.html
+++ b/content/release/0.16.4.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.17.0.html
+++ b/content/release/0.17.0.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.17.1.html
+++ b/content/release/0.17.1.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.17.2.html
+++ b/content/release/0.17.2.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.18.0.html
+++ b/content/release/0.18.0.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.18.1.html
+++ b/content/release/0.18.1.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.18.2.html
+++ b/content/release/0.18.2.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.18.3.html
+++ b/content/release/0.18.3.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.19.0.html
+++ b/content/release/0.19.0.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.19.1.html
+++ b/content/release/0.19.1.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.19.2.html
+++ b/content/release/0.19.2.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.0.html
+++ b/content/release/0.20.0.html
@@ -78,8 +78,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.1.html
+++ b/content/release/0.20.1.html
@@ -78,8 +78,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.2.html
+++ b/content/release/0.20.2.html
@@ -78,8 +78,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.203.0.html
+++ b/content/release/0.20.203.0.html
@@ -80,8 +80,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.204.0.html
+++ b/content/release/0.20.204.0.html
@@ -80,8 +80,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.20.205.0.html
+++ b/content/release/0.20.205.0.html
@@ -80,8 +80,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.21.0.html
+++ b/content/release/0.21.0.html
@@ -76,8 +76,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.22.0.html
+++ b/content/release/0.22.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.0.html
+++ b/content/release/0.23.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.1.html
+++ b/content/release/0.23.1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.10.html
+++ b/content/release/0.23.10.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.11.html
+++ b/content/release/0.23.11.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.3.html
+++ b/content/release/0.23.3.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.4.html
+++ b/content/release/0.23.4.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.5.html
+++ b/content/release/0.23.5.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.6.html
+++ b/content/release/0.23.6.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.7.html
+++ b/content/release/0.23.7.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.8.html
+++ b/content/release/0.23.8.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/0.23.9.html
+++ b/content/release/0.23.9.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.0.html
+++ b/content/release/1.0.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.1.html
+++ b/content/release/1.0.1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.2.html
+++ b/content/release/1.0.2.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.3.html
+++ b/content/release/1.0.3.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.0.4.html
+++ b/content/release/1.0.4.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.1.0.html
+++ b/content/release/1.1.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.1.1.html
+++ b/content/release/1.1.1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.1.2.html
+++ b/content/release/1.1.2.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.2.0.html
+++ b/content/release/1.2.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/1.2.1.html
+++ b/content/release/1.2.1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.0-alpha.html
+++ b/content/release/2.0.0-alpha.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.1-alpha.html
+++ b/content/release/2.0.1-alpha.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.2-alpha.html
+++ b/content/release/2.0.2-alpha.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.3-alpha.html
+++ b/content/release/2.0.3-alpha.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.4-alpha.html
+++ b/content/release/2.0.4-alpha.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.5-alpha.html
+++ b/content/release/2.0.5-alpha.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.0.6-alpha.html
+++ b/content/release/2.0.6-alpha.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.1.0-beta.html
+++ b/content/release/2.1.0-beta.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.1.1-beta.html
+++ b/content/release/2.1.1-beta.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.10.0.html
+++ b/content/release/2.10.0.html
@@ -81,8 +81,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.10.1.html
+++ b/content/release/2.10.1.html
@@ -81,8 +81,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.2.0.html
+++ b/content/release/2.2.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.3.0.html
+++ b/content/release/2.3.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.4.0.html
+++ b/content/release/2.4.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.4.1.html
+++ b/content/release/2.4.1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.5.0.html
+++ b/content/release/2.5.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.5.1.html
+++ b/content/release/2.5.1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.5.2.html
+++ b/content/release/2.5.2.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.0.html
+++ b/content/release/2.6.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.1.html
+++ b/content/release/2.6.1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.2.html
+++ b/content/release/2.6.2.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.3.html
+++ b/content/release/2.6.3.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.4.html
+++ b/content/release/2.6.4.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.6.5.html
+++ b/content/release/2.6.5.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.0.html
+++ b/content/release/2.7.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.1.html
+++ b/content/release/2.7.1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.2.html
+++ b/content/release/2.7.2.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.3.html
+++ b/content/release/2.7.3.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.4.html
+++ b/content/release/2.7.4.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.5.html
+++ b/content/release/2.7.5.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.6.html
+++ b/content/release/2.7.6.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.7.7.html
+++ b/content/release/2.7.7.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.0.html
+++ b/content/release/2.8.0.html
@@ -82,8 +82,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.1.html
+++ b/content/release/2.8.1.html
@@ -82,8 +82,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.2.html
+++ b/content/release/2.8.2.html
@@ -82,8 +82,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.3.html
+++ b/content/release/2.8.3.html
@@ -82,8 +82,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.4.html
+++ b/content/release/2.8.4.html
@@ -82,8 +82,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.8.5.html
+++ b/content/release/2.8.5.html
@@ -82,8 +82,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.9.0.html
+++ b/content/release/2.9.0.html
@@ -81,8 +81,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.9.1.html
+++ b/content/release/2.9.1.html
@@ -81,8 +81,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/2.9.2.html
+++ b/content/release/2.9.2.html
@@ -81,8 +81,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0-alpha1.html
+++ b/content/release/3.0.0-alpha1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0-alpha2.html
+++ b/content/release/3.0.0-alpha2.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0-alpha4.html
+++ b/content/release/3.0.0-alpha4.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0-beta1.html
+++ b/content/release/3.0.0-beta1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.0.html
+++ b/content/release/3.0.0.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.1.html
+++ b/content/release/3.0.1.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.2.html
+++ b/content/release/3.0.2.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.0.3.html
+++ b/content/release/3.0.3.html
@@ -79,8 +79,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.1.0.html
+++ b/content/release/3.1.0.html
@@ -81,8 +81,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.1.1.html
+++ b/content/release/3.1.1.html
@@ -81,8 +81,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.1.2.html
+++ b/content/release/3.1.2.html
@@ -81,8 +81,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.1.3.html
+++ b/content/release/3.1.3.html
@@ -83,8 +83,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.1.4.html
+++ b/content/release/3.1.4.html
@@ -83,8 +83,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.2.0.html
+++ b/content/release/3.2.0.html
@@ -81,8 +81,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.2.1.html
+++ b/content/release/3.2.1.html
@@ -83,8 +83,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/3.3.0.html
+++ b/content/release/3.3.0.html
@@ -82,8 +82,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/10.html
+++ b/content/release/page/10.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/11.html
+++ b/content/release/page/11.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/2.html
+++ b/content/release/page/2.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/3.html
+++ b/content/release/page/3.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/4.html
+++ b/content/release/page/4.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/5.html
+++ b/content/release/page/5.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/6.html
+++ b/content/release/page/6.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/7.html
+++ b/content/release/page/7.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/8.html
+++ b/content/release/page/8.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/release/page/9.html
+++ b/content/release/page/9.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/releases.html
+++ b/content/releases.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                
@@ -285,34 +283,6 @@
          </td>
          <td>
            <a href="/release/3.2.1.html">Announcement</a>
-         </td>
-     </tr>
-  
-
-    
-    
-    
-    
-      
-    
-
-     <tr>
-       <td>2.9.2</td>
-       <td>2018 Nov 19 </td>
-       <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/hadoop/common/hadoop-2.9.2/hadoop-2.9.2-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/hadoop/common/hadoop-2.9.2/hadoop-2.9.2-src.tar.gz.mds">checksum</a>
-         <a href="https://downloads.apache.org/hadoop/common/hadoop-2.9.2/hadoop-2.9.2-src.tar.gz.asc">signature</a>)
-        </td>
-        <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/hadoop/common/hadoop-2.9.2/hadoop-2.9.2.tar.gz">binary</a>
-          (<a href="https://downloads.apache.org/hadoop/common/hadoop-2.9.2/hadoop-2.9.2.tar.gz.mds">checksum</a>
-          <a href="https://downloads.apache.org/hadoop/common/hadoop-2.9.2/hadoop-2.9.2.tar.gz.asc">signature</a>)
-          
-          
-         </td>
-         <td>
-           <a href="/release/2.9.2.html">Announcement</a>
          </td>
      </tr>
   

--- a/content/tags.html
+++ b/content/tags.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/version_control.html
+++ b/content/version_control.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/versioning.html
+++ b/content/versioning.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/content/who.html
+++ b/content/who.html
@@ -67,8 +67,6 @@
                
                <li><a href="https://hadoop.apache.org/docs/r3.2.1/">3.2.1</a></li>
                
-               <li><a href="https://hadoop.apache.org/docs/r2.9.2/">2.9.2</a></li>
-               
                <li role="separator" class="divider"></li>
                <li><a href="https://wiki.apache.org/hadoop">Wiki</a></li>
                

--- a/src/release/2.9.2.md
+++ b/src/release/2.9.2.md
@@ -1,7 +1,6 @@
 ---
 title: Release 2.9.2 available
 date: 2018-11-19
-linked: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17435