### PR TITLE
Fix broken link to PoweredBy

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -53,7 +53,7 @@
           <h2>Who Uses Hadoop?</h2>
           <p>
             A wide variety of companies and organizations use Hadoop for both research and production.
-             Users are encouraged to add themselves to the Hadoop <a href="https://wiki.apache.org/hadoop/PoweredBy">PoweredBy wiki page</a>.</p>
+             Users are encouraged to add themselves to the Hadoop <a href="https://wiki.apache.org/hadoop2/PoweredBy">PoweredBy wiki page</a>.</p>
        </div>
        <div class="col-md-4">
          {{range where .Site.Pages "Title" "Related projects"}}


### PR DESCRIPTION
It was using the old "hadoop" wiki it's been moved to "hadoop2".