### PR TITLE
HADOOP-17821. Move Ozone to related projects section

### DIFF
--- a/content/modules.html
+++ b/content/modules.html
@@ -160,7 +160,6 @@
 <li><strong>Hadoop Distributed File System (HDFS™)</strong>: A distributed file system that provides high-throughput access to application data.</li>
 <li><strong>Hadoop YARN</strong>: A framework for job scheduling and cluster resource management.</li>
 <li><strong>Hadoop MapReduce</strong>: A YARN-based system for parallel processing of large data sets.</li>
-<li><strong><a href="https://hadoop.apache.org/ozone/">Hadoop Ozone</a></strong>: An object store for Hadoop.</li>
 </ul>
 
 </div>

--- a/content/related.html
+++ b/content/related.html
@@ -175,6 +175,8 @@ supports structured data storage for large tables.</li>
 data summarization and ad hoc querying.</li>
 <li><a href="https://mahout.apache.org/"><strong>Mahout™</strong></a>: A Scalable machine learning and data
 mining library.</li>
+<li><a href="https://ozone.apache.org"><strong>Ozone™</strong></a>: A scalable, redundant, and
+distributed object store for Hadoop.</li>
 <li><a href="https://pig.apache.org"><strong>Pig™</strong></a>: A high-level data-flow language and execution
 framework for parallel computation.</li>
 <li><a href="https://spark.apache.org"><strong>Spark™</strong></a>: A fast and general compute engine for

--- a/src/modules.md
+++ b/src/modules.md
@@ -20,4 +20,3 @@ The project includes these modules:
   - __Hadoop Distributed File System (HDFS™)__: A distributed file system that provides high-throughput access to application data.
   - __Hadoop YARN__: A framework for job scheduling and cluster resource management.
   - __Hadoop MapReduce__: A YARN-based system for parallel processing of large data sets.
-  - __[Hadoop Ozone](https://ozone.apache.org)__: An object store for Hadoop.

--- a/src/modules.md
+++ b/src/modules.md
@@ -20,4 +20,4 @@ The project includes these modules:
   - __Hadoop Distributed File System (HDFS™)__: A distributed file system that provides high-throughput access to application data.
   - __Hadoop YARN__: A framework for job scheduling and cluster resource management.
   - __Hadoop MapReduce__: A YARN-based system for parallel processing of large data sets.
-  - __[Hadoop Ozone](https://hadoop.apache.org/ozone/)__: An object store for Hadoop.
+  - __[Hadoop Ozone](https://ozone.apache.org)__: An object store for Hadoop.

--- a/src/related.md
+++ b/src/related.md
@@ -36,6 +36,8 @@ Other Hadoop-related projects at Apache include:
     data summarization and ad hoc querying.
 -   [**Mahout™**](https://mahout.apache.org/): A Scalable machine learning and data
     mining library.
+-   [**Ozone™**](https://ozone.apache.org/): A scalable, redundant, and
+    distributed object store for Hadoop.
 -   [**Pig™**](https://pig.apache.org): A high-level data-flow language and execution
     framework for parallel computation.
 -   [**Spark™**](https://spark.apache.org): A fast and general compute engine for


### PR DESCRIPTION
## What changes were proposed in this pull request?
Hi all, as Ozone was spun to TLP, it has individual web site.

Now on Modules part of Hadoop website, the link of Ozone website is old page.

IMHO there is two ways to fix it :
1. update it to new page.
2. move Ozone to Related projects part on Hadoop website

**I take way-1 currently.**
Please feel free to give me some feedback, thanks

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HADOOP-17821

## How was this patch tested?
Work well on linking to Ozone website.
