### PR TITLE
HADOOP-17838. Update link of PoweredBy wiki page

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -330,7 +330,7 @@ detail the changes since 2.10.0.</p>
           <h2>Who Uses Hadoop?</h2>
           <p>
             A wide variety of companies and organizations use Hadoop for both research and production.
-             Users are encouraged to add themselves to the Hadoop <a href="https://wiki.apache.org/hadoop/PoweredBy">PoweredBy wiki page</a>.</p>
+             Users are encouraged to add themselves to the Hadoop <a href="https://wiki.apache.org/hadoop2/PoweredBy">PoweredBy wiki page</a>.</p>
        </div>
        <div class="col-md-4">
          

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -53,7 +53,7 @@
           <h2>Who Uses Hadoop?</h2>
           <p>
             A wide variety of companies and organizations use Hadoop for both research and production.
-             Users are encouraged to add themselves to the Hadoop <a href="https://wiki.apache.org/hadoop/PoweredBy">PoweredBy wiki page</a>.</p>
+             Users are encouraged to add themselves to the Hadoop <a href="https://wiki.apache.org/hadoop2/PoweredBy">PoweredBy wiki page</a>.</p>
        </div>
        <div class="col-md-4">
          {{range where .Site.Pages "Title" "Related projects"}}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The [PoweredBy wiki page](https://cwiki.apache.org/confluence/display/hadoop/PoweredBy) on [main page](https://hadoop.apache.org/) is not found.

IMHO update it to [here](https://cwiki.apache.org/confluence/display/hadoop2/PoweredBy)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HADOOP-17838

## How was this patch tested?
Click the url directly : )
