### PR TITLE
Correct usage of Hugo & typo cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 The site is generated with [Hugo](https://gohugo.io/).
 
-To generate a site you need only one binary. Follow the install guide from the hugo site. (Typically all the package managers
-contain dedicated package, but as the hugo is written in go it's also possible to download the single binary from the release page).
+To generate a site you need only one binary. Follow the install guide from the Hugo site. (Typically all the package managers
+contain dedicated packages, but as the Hugo is written in go it's also possible to download the single binary from the release page).
 
 After the installation you can generate the site with:
 
@@ -40,7 +40,7 @@ which starts a standalone auto-refreshed web server.
 
 ## Content
 
-To create a new relase, create a file in  ```src/release``` directory. The file name should be ```<version>.md```where version is the release version.
+To create a new release, create a file in  ```src/release``` directory. The file name should be ```<version>.md```where version is the release version.
 
 Example: src/release/2.7.3.md
 
@@ -60,4 +60,4 @@ for the list of 221 bug fixes and patches since the previous release
 `linked: true` attribute means, that it will be displayed on the release page and under the documentation menu. 
 Please remove it from the previous release.
 
-Note: date is used to sort the releases when the latests are displayed in the site.
+Note: date is used to sort the releases when the latest versions are displayed in the site.


### PR DESCRIPTION
**What is this change?**

This change capitalizes `Hugo` when it is used as a proper noun. This change also corrects typos, such as spelling mistakes in `README.md`

**Why is this change necessary?**

These minor improvements will give readers a more polished reading experience. 