### PR TITLE
HADOOP-19214. Invalid GPG commands in Download page

### DIFF
--- a/content/index.xml
+++ b/content/index.xml
@@ -1404,7 +1404,7 @@ Major versions are used to introduce substantial, potentially incompatible, chan
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://hadoop.apache.org/releases.html</guid>
-      <description>To verify Apache Hadoop® releases using GPG: Download the release hadoop-X.Y.Z-src.tar.gz from a mirror site. Download the signature file hadoop-X.Y.Z-src.tar.gz.asc from Apache. Download the Hadoop KEYS file. gpg &amp;ndash;import KEYS gpg &amp;ndash;verify hadoop-X.Y.Z-src.tar.gz.asc To perform a quick check using SHA-512: Download the release hadoop-X.Y.Z-src.tar.gz from a mirror site. Download the checksum hadoop-X.Y.Z-src.tar.gz.sha512 or hadoop-X.Y.Z-src.tar.gz.mds from Apache. shasum -a 512 hadoop-X.Y.Z-src.tar.gz All previous releases of Apache Hadoop are available from the Apache release archive site.</description>
+      <description>To verify Apache Hadoop® releases using GPG: Download the release hadoop-X.Y.Z-src.tar.gz from a mirror site. Download the signature file hadoop-X.Y.Z-src.tar.gz.asc from Apache. Download the Hadoop KEYS file. gpg --import KEYS gpg --verify hadoop-X.Y.Z-src.tar.gz.asc To perform a quick check using SHA-512: Download the release hadoop-X.Y.Z-src.tar.gz from a mirror site. Download the checksum hadoop-X.Y.Z-src.tar.gz.sha512 or hadoop-X.Y.Z-src.tar.gz.mds from Apache. shasum -a 512 hadoop-X.Y.Z-src.tar.gz All previous releases of Apache Hadoop are available from the Apache release archive site.</description>
     </item>
     
     <item>

--- a/content/releases.html
+++ b/content/releases.html
@@ -281,8 +281,8 @@ site</a>.</li>
 <a href="https://downloads.apache.org/hadoop/common/">Apache</a>.</li>
 <li>Download the <a href="https://downloads.apache.org/hadoop/common/KEYS">Hadoop
 KEYS</a> file.</li>
-<li>gpg &ndash;import KEYS</li>
-<li>gpg &ndash;verify hadoop-X.Y.Z-src.tar.gz.asc</li>
+<li>gpg --import KEYS</li>
+<li>gpg --verify hadoop-X.Y.Z-src.tar.gz.asc</li>
 </ol>
 <h2 id="to-perform-a-quick-check-using-sha-512">To perform a quick check using SHA-512:</h2>
 <ol>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instructions in [Download page](https://hadoop.apache.org/releases.html) shows GPG commands with `--` converted to &ndash;:

```
gpg –import KEYS
gpg –verify hadoop-X.Y.Z-src.tar.gz.asc
```

which makes the commands invalid:

```
$ gpg –import KEYS      
gpg: WARNING: no command supplied.  Trying to guess what you mean ...
usage: gpg [options] [filename]
```

https://issues.apache.org/jira/browse/HADOOP-19214

## How was this patch tested?

```
$ gpg --import KEYS
gpg: can't open 'KEYS': No such file or directory
gpg: Total number processed: 0

$ gpg --verify hadoop-X.Y.Z-src.tar.gz.asc
gpg: can't open 'hadoop-X.Y.Z-src.tar.gz.asc': No such file or directory
gpg: verify signatures failed: No such file or directory
```