### PR TITLE
HADOOP-19459. Comply with ASF website policy.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,15 +48,10 @@ publishDir = "content"
    parent = "documentation"
    url = "https://hadoop.apache.org/docs/stable/"
 
-
-
-
 [[menu.main]]
    name = "Community"
    identifier = "community"
    weight = 3
-
-
 
 [[menu.main]]
    name = "Development"
@@ -69,25 +64,49 @@ publishDir = "content"
   parent = "development"
 
 [[menu.main]]
-   name = "Help"
-   identifier = "help"
+   name = "Apache Software Foundation"
+   identifier = "apache"
    weight = 5
+
+[[menu.main]]
+   name = "Apache Home"
+   url = "https://www.apache.org"
+   parent = "apache"
 
 [[menu.main]]
    name = "Buy Stuff"
    url = "https://www.cafepress.com/hadoop"
-   parent = "help"
+   parent = "apache"
 
 [[menu.main]]
    name = "Sponsorship"
    url = "https://www.apache.org/foundation/sponsorship.html"
-   parent = "help"
+   parent = "apache"
 
 [[menu.main]]
    name = "Thanks"
    url = "https://www.apache.org/foundation/thanks.html"
-   parent = "help"
+   parent = "apache"
 
+[[menu.main]]
+   name = "License"
+   url = "https://www.apache.org/licenses"
+   parent = "apache"
+
+[[menu.main]]
+   name = "Security"
+   url = "https://www.apache.org/security"
+   parent = "apache"
+
+[[menu.main]]
+   name = "Event"
+   url = "https://events.apache.org"
+   parent = "apache"
+
+[[menu.main]]
+   name = "Privacy Policy"
+   url = "https://privacy.apache.org/policies/privacy-policy-public.html"
+   parent = "apache"
 
 # Configure the English version of the website.
 [languages.en]

--- a/content/bylaws.html
+++ b/content/bylaws.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -275,7 +278,7 @@ decision must be ratified by the Apache board.</p>
 </ul>
 <h1 id="decision-making">Decision Making</h1>
 <p>Within the Hadoop project, different types of decisions require
-different forms of approval. For example, the <a href="/bylaws.html#Roles+and+Responsibilities">previous
+different forms of approval. For example, the <a href="#Roles+and+Responsibilities">previous
 section</a> describes several decisions which
 require &ldquo;consensus approval&rdquo; approval. This section defines how voting
 is performed, the types of approvals, and which types of decision
@@ -442,7 +445,7 @@ votes are subject to the above timeframe of 7 days.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -453,12 +456,24 @@ votes are subject to the above timeframe of 7 days.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/categories.html
+++ b/content/categories.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -162,7 +165,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -173,12 +176,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/categories/index.xml
+++ b/content/categories/index.xml
@@ -4,9 +4,8 @@
     <title>Categories on Apache Hadoop</title>
     <link>https://hadoop.apache.org/categories.html</link>
     <description>Recent content in Categories on Apache Hadoop</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <copyright>Copyright © 2006-{year} The Apache Software Foundation</copyright>
-    <atom:link href="https://hadoop.apache.org/categories/index.xml" rel="self" type="application/rss+xml" />
+    <copyright>Copyright © 2006-{year} The Apache Software Foundation</copyright><atom:link href="https://hadoop.apache.org/categories/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/content/committer_criteria.html
+++ b/content/committer_criteria.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -249,7 +252,7 @@ knowledge of the project, attention to detail, and also his user-focus.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -260,12 +263,24 @@ knowledge of the project, attention to detail, and also his user-focus.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/cve_list.html
+++ b/content/cve_list.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -158,7 +161,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<p>This page lists security fixes that the Hadoop PMC felt warranted a CVE. If you think something is missing from this list or if you think the set of impacted or fixed versions is incomplete then please <a href="/mailing_lists.html#Security">ask on the Security list</a>.</p>
+<p>This page lists security fixes that the Hadoop PMC felt warranted a CVE. If you think something is missing from this list or if you think the set of impacted or fixed versions is incomplete then please <a href="mailing_lists.html#Security">ask on the Security list</a>.</p>
 <p>CVEs are presented in most-recent-first order of announcement.</p>
 <!-- These should be sorted as most-recent-first. Please copy this template and fill in as needed.
 
@@ -483,7 +486,7 @@ target encryption zone.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -494,12 +497,24 @@ target encryption zone.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/description.html
+++ b/content/description.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -158,7 +161,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<p><img alt="hadoop-logo" src="hadoop-logo.jpg"> Apache Hadoop</p>
+<p><img src="hadoop-logo.jpg" alt="hadoop-logo"> Apache Hadoop</p>
 <p>The Apache® Hadoop® project develops open-source software for reliable, scalable, distributed computing.</p>
 <p>The Apache Hadoop software library is a framework that allows for the distributed processing of large data sets across clusters of computers using simple programming models. It is designed to scale up from single servers to thousands of machines, each offering local computation and storage. Rather than rely on hardware to deliver high-availability, the library itself is designed to detect and handle failures at the application layer, so delivering a highly-available service on top of a cluster of computers, each of which may be prone to failures.</p>
 
@@ -170,7 +173,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -181,12 +184,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/index.html
+++ b/content/index.html
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-	<meta name="generator" content="Hugo 0.137.1">
+	<meta name="generator" content="Hugo 0.111.3">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -11,7 +11,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -117,10 +117,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -131,13 +141,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -162,7 +165,7 @@
   See the License for the specific language governing permissions and
   limitations under the License. See accompanying LICENSE file.
 -->
-<p><img alt="hadoop-logo" src="hadoop-logo.jpg"> Apache Hadoop</p>
+<p><img src="hadoop-logo.jpg" alt="hadoop-logo"> Apache Hadoop</p>
 <p>The Apache® Hadoop® project develops open-source software for reliable, scalable, distributed computing.</p>
 <p>The Apache Hadoop software library is a framework that allows for the distributed processing of large data sets across clusters of computers using simple programming models. It is designed to scale up from single servers to thousands of machines, each offering local computation and storage. Rather than rely on hardware to deliver high-availability, the library itself is designed to detect and handle failures at the application layer, so delivering a highly-available service on top of a cluster of computers, each of which may be prone to failures.</p>
 
@@ -465,7 +468,7 @@ service for distributed applications.</li>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -476,12 +479,24 @@ service for distributed applications.</li>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/index.xml
+++ b/content/index.xml
@@ -4,1053 +4,1537 @@
     <title>Apache Hadoop</title>
     <link>https://hadoop.apache.org/</link>
     <description>Recent content on Apache Hadoop</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <copyright>Copyright © 2006-{year} The Apache Software Foundation</copyright>
-    <lastBuildDate>Fri, 18 Oct 2024 00:00:00 +0000</lastBuildDate>
-    <atom:link href="https://hadoop.apache.org/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Fri, 18 Oct 2024 00:00:00 +0000</lastBuildDate><atom:link href="https://hadoop.apache.org/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Release 3.4.1 available</title>
       <link>https://hadoop.apache.org/release/3.4.1.html</link>
       <pubDate>Fri, 18 Oct 2024 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.4.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a release of Apache Hadoop 3.4.1 line.&lt;/p&gt;</description>
+      <description>This is a release of Apache Hadoop 3.4.1 line.
+Users of Apache Hadoop 3.4.0 and earlier should upgrade to this release.
+All users are encouraged to read the overview of major changes since release 3.4.0.
+We have also introduced a lean tar which is a small tar file that does not contain the AWS SDK because the size of AWS SDK is itself 500 MB. This can ease usage for non AWS users.</description>
     </item>
+    
     <item>
       <title>Release 3.4.0 available</title>
       <link>https://hadoop.apache.org/release/3.4.0.html</link>
       <pubDate>Sun, 17 Mar 2024 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.4.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first release of Apache Hadoop 3.4 line. It contains 2888 bug fixes, improvements and enhancements since 3.3.&lt;/p&gt;</description>
+      <description>This is the first release of Apache Hadoop 3.4 line. It contains 2888 bug fixes, improvements and enhancements since 3.3.
+Users are encouraged to read the overview of major changes. For details of please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.3.6 available</title>
       <link>https://hadoop.apache.org/release/3.3.6.html</link>
       <pubDate>Fri, 23 Jun 2023 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.6.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a release of Apache Hadoop 3.3 line.&lt;/p&gt;</description>
+      <description>This is a release of Apache Hadoop 3.3 line.
+It contains 117 bug fixes, improvements and enhancements since 3.3.5. Users of Apache Hadoop 3.3.5 and earlier should upgrade to this release.
+Feature highlights:
+SBOM artifacts Starting from this release, Hadoop publishes Software Bill of Materials (SBOM) using CycloneDX Maven plugin. For more information on SBOM, please go to SBOM.
+HDFS RBF: RDBMS based token storage support HDFS Router-Router Based Federation now supports storing delegation tokens on MySQL, HADOOP-18535 which improves token operation through over the original Zookeeper-based implementation.</description>
     </item>
+    
     <item>
       <title>Release 3.3.5 available</title>
       <link>https://hadoop.apache.org/release/3.3.5.html</link>
       <pubDate>Wed, 22 Mar 2023 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a release of Apache Hadoop 3.3 line.&lt;/p&gt;</description>
+      <description>This is a release of Apache Hadoop 3.3 line.
+Key changes include
+A big update of dependencies to try and keep those reports of transitive CVEs under control -both genuine and false positives. Critical fix to ABFS input stream prefetching for correct reading. Vectored IO API for all FSDataInputStream implementations, with high-performance versions for file:// and s3a:// filesystems. file:// through java native IO s3a:// parallel GET requests. Arm64 binaries. Note, because the arm64 release was on a different platform, the jar files may not match those of the x86 release -and therefore the maven artifacts.</description>
     </item>
+    
     <item>
       <title>Release 3.3.4 available</title>
       <link>https://hadoop.apache.org/release/3.3.4.html</link>
       <pubDate>Mon, 08 Aug 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a release of Apache Hadoop 3.3 line.&lt;/p&gt;</description>
+      <description>This is a release of Apache Hadoop 3.3 line.
+It contains a small number security and critical integration fixes since 3.3.3.
+Users of Apache Hadoop 3.3.3 should upgrade to this release.
+Users of hadoop 2.x and hadoop 3.2 should also upgrade to the 3.3.x line. As well as feature enhancements, this is the sole branch currently receiving fixes for anything other than critical security/data integrity issues.
+Users are encouraged to read the overview of major changes since release 3.</description>
     </item>
+    
     <item>
       <title>Release 3.2.4 available</title>
       <link>https://hadoop.apache.org/release/3.2.4.html</link>
       <pubDate>Fri, 22 Jul 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the third stable release of Apache Hadoop 3.2 line.&lt;/p&gt;</description>
+      <description>This is the third stable release of Apache Hadoop 3.2 line.
+It contains 153 bug fixes, improvements and enhancements since 3.2.3.
+Users are encouraged to read the overview of major changes since 3.2.3. For details of 153 bug fixes, improvements, and other enhancements since the previous 3.2.3 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 2.10.2 available</title>
       <link>https://hadoop.apache.org/release/2.10.2.html</link>
       <pubDate>Tue, 31 May 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.10.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 2.10 line.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 2.10 line.
+It contains 211 bug fixes, improvements and enhancements since 2.10.1.
+Users are encouraged to read the overview of major changes since 2.10.1. For details of 211 bug fixes, improvements, and other enhancements since the previous 2.10.1 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.3.3 available</title>
       <link>https://hadoop.apache.org/release/3.3.3.html</link>
       <pubDate>Tue, 17 May 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the third stable release of the Apache Hadoop 3.3 line.&lt;/p&gt;</description>
+      <description>This is the third stable release of the Apache Hadoop 3.3 line.
+It contains 23 bug fixes, improvements and enhancements since 3.3.2.
+This is primarily a security update; for this reason, upgrading is strongly advised.
+Users are encouraged to read the overview of major changes since 3.3.2. For details of bug fixes, improvements, and other enhancements since the previous 3.3.2 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.2.3 available</title>
       <link>https://hadoop.apache.org/release/3.2.3.html</link>
       <pubDate>Mon, 28 Mar 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the third stable release of Apache Hadoop 3.2 line. It contains 328 bug fixes, improvements and enhancements since 3.2.2.&lt;/p&gt;</description>
+      <description>This is the third stable release of Apache Hadoop 3.2 line. It contains 328 bug fixes, improvements and enhancements since 3.2.2.
+Users are encouraged to read the overview of major changes since 3.2.2. For details of 328 bug fixes, improvements, and other enhancements since the previous 3.2.2 release, please check release notes and changelog detail the changes since 3.2.2.</description>
     </item>
+    
     <item>
       <title>Release 3.3.2 available</title>
       <link>https://hadoop.apache.org/release/3.3.2.html</link>
       <pubDate>Thu, 03 Mar 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.3 line. It contains 284 bug fixes, improvements and enhancements since 3.3.1.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.3 line. It contains 284 bug fixes, improvements and enhancements since 3.3.1.
+Users are encouraged to read the overview of major changes since 3.3.1. For details of 284 bug fixes, improvements, and other enhancements since the previous 3.3.1 release, please check release notes and changelog detail the changes since 3.3.1.</description>
     </item>
+    
     <item>
       <title>Hadoop is not susceptible to log4shell vulnerability</title>
       <link>https://hadoop.apache.org/news/2021-12-17-log4shell.html</link>
       <pubDate>Fri, 17 Dec 2021 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2021-12-17-log4shell.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop, as of today depends on log4j 1.x, which is &lt;em&gt;NOT&lt;/em&gt; susceptible to the attack (CVE-2021-44228).&lt;/p&gt;</description>
+      <description>Hadoop, as of today depends on log4j 1.x, which is NOT susceptible to the attack (CVE-2021-44228).
+For more information check the published CVEs page.</description>
     </item>
+    
     <item>
       <title>Release 3.3.1 available</title>
       <link>https://hadoop.apache.org/release/3.3.1.html</link>
       <pubDate>Tue, 15 Jun 2021 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first stable release of Apache Hadoop 3.3.x line. It contains 697 bug fixes, improvements and enhancements since 3.3.0.&lt;/p&gt;</description>
+      <description>This is the first stable release of Apache Hadoop 3.3.x line. It contains 697 bug fixes, improvements and enhancements since 3.3.0.
+Users are encouraged to read the overview of major changes since 3.3.0. For details of 697 bug fixes, improvements, and other enhancements since the previous 3.3.0 release, please check release notes and changelog detail the changes since 3.3.0.</description>
     </item>
+    
     <item>
       <title>Ozone 1.1.0 is released</title>
       <link>https://hadoop.apache.org/news/2021-04-17-ozone-1.1.0.html</link>
       <pubDate>Sat, 17 Apr 2021 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2021-04-17-ozone-1.1.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;General available(GA) release of Apache Hadoop Ozone with Volume/Bucket Quota Support, Security related enhancements, ofs/o3fs performance improvements, Recon improvements etc.&lt;/p&gt;</description>
+      <description>General available(GA) release of Apache Hadoop Ozone with Volume/Bucket Quota Support, Security related enhancements, ofs/o3fs performance improvements, Recon improvements etc.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Release 3.2.2 available</title>
       <link>https://hadoop.apache.org/release/3.2.2.html</link>
       <pubDate>Sat, 09 Jan 2021 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.2 line. It contains 516 bug fixes, improvements and enhancements since 3.2.1.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.2 line. It contains 516 bug fixes, improvements and enhancements since 3.2.1.
+Users are encouraged to read the overview of major changes since 3.2.1. For details of 516 bug fixes, improvements, and other enhancements since the previous 3.2.1 release, please check release notes and changelog detail the changes since 3.2.1.</description>
     </item>
+    
     <item>
       <title>Release 2.10.1 available</title>
       <link>https://hadoop.apache.org/release/2.10.1.html</link>
       <pubDate>Mon, 21 Sep 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.10.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 2.10 line. It contains 218 bug fixes, improvements and enhancements since 2.10.0.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 2.10 line. It contains 218 bug fixes, improvements and enhancements since 2.10.0.
+Users are encouraged to read the overview of major changes since 2.10.0. For details of 218 bug fixes, improvements, and other enhancements since the previous 2.10.0 release, please check release notes and changelog detail the changes since 2.10.0.</description>
     </item>
+    
     <item>
       <title>Ozone 1.0.0 is released</title>
       <link>https://hadoop.apache.org/news/2020-09-02-ozone-1.0.0.html</link>
       <pubDate>Wed, 02 Sep 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2020-09-02-ozone-1.0.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;First general available(GA) release of Apache Hadoop Ozone with OM HA, OFS, Security phase II, Ozone Filesystem performance improvement, security enabled Hadoop 2.x support, bucket link, Recon / Recon UI improvment, etc.&lt;/p&gt;</description>
+      <description>First general available(GA) release of Apache Hadoop Ozone with OM HA, OFS, Security phase II, Ozone Filesystem performance improvement, security enabled Hadoop 2.x support, bucket link, Recon / Recon UI improvment, etc.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Release 3.1.4 available</title>
       <link>https://hadoop.apache.org/release/3.1.4.html</link>
       <pubDate>Mon, 03 Aug 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.1 line. It contains 308 bug fixes, improvements and enhancements since 3.1.3.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.1 line. It contains 308 bug fixes, improvements and enhancements since 3.1.3.
+Users are encouraged to read the overview of major changes since 3.1.3. For details of 308 bug fixes, improvements, and other enhancements since the previous 3.1.3 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.3.0 available</title>
       <link>https://hadoop.apache.org/release/3.3.0.html</link>
       <pubDate>Tue, 14 Jul 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first release of Apache Hadoop 3.3 line. It contains 2148 bug fixes, improvements and enhancements since 3.2.&lt;/p&gt;</description>
+      <description>This is the first release of Apache Hadoop 3.3 line. It contains 2148 bug fixes, improvements and enhancements since 3.2.
+Users are encouraged to read the overview of major changes. For details of please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Ozone 0.5.0-beta is released</title>
       <link>https://hadoop.apache.org/news/2020-03-24-ozone-0.5.0-beta.html</link>
       <pubDate>Tue, 24 Mar 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2020-03-24-ozone-0.5.0-beta.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;First beta release of Apache Hadoop Ozone with GDPR Right to Erasure, Network Topology Awareness, O3FS, and improved scalability/stability.&lt;/p&gt;</description>
+      <description>First beta release of Apache Hadoop Ozone with GDPR Right to Erasure, Network Topology Awareness, O3FS, and improved scalability/stability.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Release 2.10.0 available</title>
       <link>https://hadoop.apache.org/release/2.10.0.html</link>
       <pubDate>Tue, 29 Oct 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.10.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first stable release of Apache Hadoop 2.10 line. It contains 362 bug fixes, improvements and enhancements since 2.9.0.&lt;/p&gt;</description>
+      <description>This is the first stable release of Apache Hadoop 2.10 line. It contains 362 bug fixes, improvements and enhancements since 2.9.0.
+Users are encouraged to read the overview of major changes since 2.9.0. For details of 362 bug fixes, improvements, and other enhancements since the previous 2.9.0 release, please check release notes and changelog detail the changes since 2.9.0.</description>
     </item>
+    
     <item>
       <title>Release 3.1.3 available</title>
       <link>https://hadoop.apache.org/release/3.1.3.html</link>
       <pubDate>Mon, 21 Oct 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the third stable release of Apache Hadoop 3.1 line. It contains 246 bug fixes, improvements and enhancements since 3.1.2.&lt;/p&gt;</description>
+      <description>This is the third stable release of Apache Hadoop 3.1 line. It contains 246 bug fixes, improvements and enhancements since 3.1.2.
+Users are encouraged to read the overview of major changes since 3.1.2. For details of the bug fixes, improvements, and other enhancements since the previous 3.1.2 release, please check release notes and changelog</description>
     </item>
+    
     <item>
       <title>Ozone 0.4.1-alpha is released</title>
       <link>https://hadoop.apache.org/news/2019-10-13-ozone-0.4.1-alpha.html</link>
       <pubDate>Sun, 13 Oct 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2019-10-13-ozone-0.4.1-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Next version of Apache Hadoop Ozone is released with  Native ACLs, K8s support and improved stability.&lt;/p&gt;</description>
+      <description>Next version of Apache Hadoop Ozone is released with Native ACLs, K8s support and improved stability.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Release 3.2.1 available</title>
       <link>https://hadoop.apache.org/release/3.2.1.html</link>
       <pubDate>Sun, 22 Sep 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.2 line. It contains 493 bug fixes, improvements and enhancements since 3.2.0&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.2 line. It contains 493 bug fixes, improvements and enhancements since 3.2.0
+Users are encouraged to read the overview of major changes since 3.2.0 For details of 493 bug fixes, improvements, and other enhancements since the previous 3.2.0 release, please check release notes and changelog detail the changes since 3.2.0</description>
     </item>
+    
     <item>
       <title>Ozone 0.4.0-alpha is released</title>
       <link>https://hadoop.apache.org/news/2019-05-07-ozone-0.4.0-alpha.html</link>
       <pubDate>Tue, 07 May 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2019-05-07-ozone-0.4.0-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Ozone 0.4.0 alpha version supports kerberos and transparent data encryption.&#xA;This is first secure Ozone release. It is compatible with apache Spark, Hive&#xA;and Yarn.&lt;/p&gt;</description>
+      <description>Ozone 0.4.0 alpha version supports kerberos and transparent data encryption. This is first secure Ozone release. It is compatible with apache Spark, Hive and Yarn.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Release 3.1.2 available</title>
       <link>https://hadoop.apache.org/release/3.1.2.html</link>
       <pubDate>Wed, 06 Feb 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.1 line. It contains 325 bug fixes, improvements and enhancements since 3.1.1.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.1 line. It contains 325 bug fixes, improvements and enhancements since 3.1.1.
+Users are encouraged to read the overview of major changes since 3.0.x. For details of 325 bug fixes, improvements, and other enhancements since the previous 3.1.1 release, please check release notes and changelog</description>
     </item>
+    
     <item>
       <title>Release 3.2.0 available</title>
       <link>https://hadoop.apache.org/release/3.2.0.html</link>
       <pubDate>Wed, 16 Jan 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first stable release of Apache Hadoop 3.2 line. It contains 1092 bug fixes, improvements and enhancements since 3.1.0.&lt;/p&gt;</description>
+      <description>This is the first stable release of Apache Hadoop 3.2 line. It contains 1092 bug fixes, improvements and enhancements since 3.1.0.
+Users are encouraged to read the overview of major changes since 3.1.0. For details of 1092 bug fixes, improvements, and other enhancements since the previous 3.1.0 release, please check release notes and changelog detail the changes since 3.1.0.</description>
     </item>
+    
     <item>
       <title>Ozone 0.3.0-alpha is released</title>
       <link>https://hadoop.apache.org/news/2018-11-22-ozone-0.3.0-alpha.html</link>
       <pubDate>Thu, 22 Nov 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2018-11-22-ozone-0.3.0-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Next version of Apache Hadoop Ozone is released with S3 support and improved stability.&lt;/p&gt;</description>
+      <description>Next version of Apache Hadoop Ozone is released with S3 support and improved stability.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Release 2.9.2 available</title>
       <link>https://hadoop.apache.org/release/2.9.2.html</link>
       <pubDate>Mon, 19 Nov 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.9.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.9 line. It contains 204 bug fixes, improvements and enhancements since 2.9.1.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.9 line. It contains 204 bug fixes, improvements and enhancements since 2.9.1.
+Users are encouraged to read the overview of major changes since 2.9.1. For details of 204 bug fixes, improvements, and other enhancements since the previous 2.9.1 release, please check release notes and changelog detail the changes since 2.9.1.</description>
     </item>
+    
     <item>
       <title>Ozone release 0.2.1-alpha available</title>
       <link>https://hadoop.apache.org/news/2018-10-01-ozone-0.2.1-alpha.html</link>
       <pubDate>Mon, 01 Oct 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2018-10-01-ozone-0.2.1-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first version of Apache Hadoop Ozone. Ozone is an Object store for Hadoop built&#xA;using Hadoop Distributed Data Store.&lt;/p&gt;</description>
+      <description>This is the first version of Apache Hadoop Ozone. Ozone is an Object store for Hadoop built using Hadoop Distributed Data Store.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Release 2.8.5 available</title>
       <link>https://hadoop.apache.org/release/2.8.5.html</link>
       <pubDate>Sat, 15 Sep 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.8 line. It contains 33 bug&#xA;fixes, improvements and enhancements since 2.8.5.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.8 line. It contains 33 bug fixes, improvements and enhancements since 2.8.5.
+Users are encouraged to read the overview of major changes for major features and improvements for Apache Hadoop 2.8. For details of 33 fixes, improvements, and other enhancements since the 2.8.4 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.1.1 available</title>
       <link>https://hadoop.apache.org/release/3.1.1.html</link>
       <pubDate>Wed, 08 Aug 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first stable release of Apache Hadoop 3.1 line. It contains 435 bug fixes, improvements and enhancements since 3.1.0.&lt;/p&gt;</description>
+      <description>This is the first stable release of Apache Hadoop 3.1 line. It contains 435 bug fixes, improvements and enhancements since 3.1.0.
+Users are encouraged to read the overview of major changes since 3.1.0. For details of 435 bug fixes, improvements, and other enhancements since the previous 3.1.0 release, please check (https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-common/release/3.1.1/RELEASENOTES.3.1.1.html) and changelog detail the changes since 3.1.0.</description>
     </item>
+    
     <item>
       <title>Release 2.7.7 available</title>
       <link>https://hadoop.apache.org/release/2.7.7.html</link>
       <pubDate>Thu, 31 May 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.7.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a maintenance release of Apache Hadoop 2.7. It addresses CVE-2018-8009.&lt;/p&gt;</description>
+      <description>This is a maintenance release of Apache Hadoop 2.7. It addresses CVE-2018-8009.</description>
     </item>
+    
     <item>
       <title>Release 3.0.3 available</title>
       <link>https://hadoop.apache.org/release/3.0.3.html</link>
       <pubDate>Thu, 31 May 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 3.0 line. It contains 249 bug&#xA;fixes, improvments and other enhancements since 3.0.2.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 3.0 line. It contains 249 bug fixes, improvments and other enhancements since 3.0.2.
+Users are encouraged to read the overview of major changes since 3.0.2. For details of 249 bug fixes, improvements, and other enhancements since the previous 3.0.2 release, please check release notes andi changelog detail the changes since 3.0.2.</description>
     </item>
+    
     <item>
       <title>Release 2.8.4 available</title>
       <link>https://hadoop.apache.org/release/2.8.4.html</link>
       <pubDate>Tue, 15 May 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.8 line. It contains 77 bug&#xA;fixes, improvements and enhancements since 2.8.3.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.8 line. It contains 77 bug fixes, improvements and enhancements since 2.8.3.
+Users are encouraged to read the overview of major changes for major features and improvements for Apache Hadoop 2.8. For details of 77 fixes, improvements, and other enhancements since the 2.8.3 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 2.9.1 available</title>
       <link>https://hadoop.apache.org/release/2.9.1.html</link>
       <pubDate>Thu, 03 May 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.9.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.9 line. It contains 208 bug&#xA;fixes, improvements and enhancements since 2.9.0.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.9 line. It contains 208 bug fixes, improvements and enhancements since 2.9.0.
+Users are encouraged to read the overview of major changes for major features and improvements for Apache Hadoop 2.9. For details of 208 fixes, improvements, and other enhancements since the 2.9.0 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.0.2 available</title>
       <link>https://hadoop.apache.org/release/3.0.2.html</link>
       <pubDate>Sat, 21 Apr 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 3.0 line. This release fixes&#xA;the shard jars published in Hadoop 3.0.1.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 3.0 line. This release fixes the shard jars published in Hadoop 3.0.1.
+Please see the Hadoop 3.0.2 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.7.6 available</title>
       <link>https://hadoop.apache.org/release/2.7.6.html</link>
       <pubDate>Mon, 16 Apr 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.6.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.7 line.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.7 line.
+Please see the Hadoop 2.7.6 Release Notes for the full list of 46 bug fixes and optimizations since the previous release 2.7.5. It particularly enables POSIX groups support for LDAP groups mapping service.</description>
     </item>
+    
     <item>
       <title>Release 3.1.0 available</title>
       <link>https://hadoop.apache.org/release/3.1.0.html</link>
       <pubDate>Fri, 06 Apr 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first release of Apache Hadoop 3.1 line. It contains 768 bug&#xA;fixes, improvements and enhancements since 3.0.0&lt;/p&gt;</description>
+      <description>This is the first release of Apache Hadoop 3.1 line. It contains 768 bug fixes, improvements and enhancements since 3.0.0
+Users are encouraged to read the overview of major changes since 3.0.0. For details of 768 bug fixes, improvements, and other enhancements since the previous 3.0.0 release, please check release notes and changelog detail the changes since 3.0.0.</description>
     </item>
+    
     <item>
       <title>Release 3.0.1 available</title>
       <link>https://hadoop.apache.org/release/3.0.1.html</link>
       <pubDate>Sun, 25 Mar 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;After four alpha releases and one beta release, 3.0.0 is generally&#xA;available. 3.0.0 consists of 302 bug fixes, improvements, and other&#xA;enhancements since 3.0.0-beta1. All together, 6242 issues were fixed as&#xA;part of the 3.0.0 release series since 2.7.0.&lt;/p&gt;</description>
+      <description>After four alpha releases and one beta release, 3.0.0 is generally available. 3.0.0 consists of 302 bug fixes, improvements, and other enhancements since 3.0.0-beta1. All together, 6242 issues were fixed as part of the 3.0.0 release series since 2.7.0.
+This is the next release of Apache Hadoop 3.0 line. It contains 49 bug fixes, improvements and enhancements since 3.0.0.
+Please note: 3.0.0 is deprecated after 3.0.1 because HDFS-12990 changes NameNode default RPC port back to 8020.</description>
     </item>
+    
     <item>
       <title>Release 2.9.0 available</title>
       <link>https://hadoop.apache.org/release/2.9.0.html</link>
       <pubDate>Sun, 17 Dec 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.9.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first GA release in the 2.9 release line. It includes 30 New&#xA;Features with 500+ subtasks, 407 Improvements, 790 Bug fixes new fixed&#xA;issues since 2.8.2. For major features and improvements for Apache&#xA;Hadoop 2.8.2 please refer: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.9.0/index.html&#34;&gt;overview of major&#xA;changes&lt;/a&gt;. For details&#xA;of 790 bug fixes, improvements, and other enhancements since the&#xA;previous 2.8.2 release, please check: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.9.0/hadoop-project-dist/hadoop-common/release/2.9.0/RELEASENOTES.2.9.0.html&#34;&gt;release&#xA;notes&lt;/a&gt;&#xA;and&#xA;&lt;a href=&#34;https://hadoop.apache.org/docs/r2.9.0/hadoop-project-dist/hadoop-common/release/2.9.0/CHANGES.2.9.0.html&#34;&gt;changelog&lt;/a&gt;&lt;/p&gt;</description>
+      <description>This is the first GA release in the 2.9 release line. It includes 30 New Features with 500+ subtasks, 407 Improvements, 790 Bug fixes new fixed issues since 2.8.2. For major features and improvements for Apache Hadoop 2.8.2 please refer: overview of major changes. For details of 790 bug fixes, improvements, and other enhancements since the previous 2.8.2 release, please check: release notes and changelog
+Please note: Although this release has been tested on fairly large clusters, production users can wait for a subsequent point release which will contain fixes from further stabilization and downstream adoption.</description>
     </item>
+    
     <item>
       <title>Release 2.7.5 available</title>
       <link>https://hadoop.apache.org/release/2.7.5.html</link>
       <pubDate>Thu, 14 Dec 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.7 line.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.7 line.
+Please see the Hadoop 2.7.5 Release Notes for the list of 34 bug fixes and optimizations since the previous release 2.7.4.</description>
     </item>
+    
     <item>
       <title>Release 3.0.0 generally available</title>
       <link>https://hadoop.apache.org/release/3.0.0.html</link>
       <pubDate>Wed, 13 Dec 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;After four alpha releases and one beta release, 3.0.0 is generally&#xA;available. 3.0.0 consists of 302 bug fixes, improvements, and other&#xA;enhancements since 3.0.0-beta1. All together, 6242 issues were fixed as&#xA;part of the 3.0.0 release series since 2.7.0.&lt;/p&gt;</description>
+      <description>After four alpha releases and one beta release, 3.0.0 is generally available. 3.0.0 consists of 302 bug fixes, improvements, and other enhancements since 3.0.0-beta1. All together, 6242 issues were fixed as part of the 3.0.0 release series since 2.7.0.
+Users are encouraged to read the overview of major changes in 3.0.0. The GA release notes and changelog detail the changes since 3.0.0-beta1.</description>
     </item>
+    
     <item>
       <title>Release 2.8.3 available</title>
       <link>https://hadoop.apache.org/release/2.8.3.html</link>
       <pubDate>Tue, 12 Dec 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.8 release line. It contains&#xA;79 bug fixes, improvments and other enhancements since 2.8.2.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.8 release line. It contains 79 bug fixes, improvments and other enhancements since 2.8.2.
+For major features and improvements for Apache Hadoop 2.8, please refer: overview of major changes. For details of 79 fixes, improvements, and other enhancements since the previous 2.8.2 release, please check: release notes and changelog</description>
     </item>
+    
     <item>
       <title>Release 2.8.2 available</title>
       <link>https://hadoop.apache.org/release/2.8.2.html</link>
       <pubDate>Tue, 24 Oct 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first GA release in the 2.8 release line. It contains 315&#xA;bug fixes, improvments and other enhancements since 2.8.1. For major&#xA;features and improvements for Apache Hadoop 2.8, please refer: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.2/index.html&#34;&gt;overview&#xA;of major changes&lt;/a&gt;. For&#xA;details of 315 fixes, improvements, and other enhancements since the&#xA;previous 2.8.1 release, please check: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.2/hadoop-project-dist/hadoop-common/release/2.8.2/RELEASENOTES.2.8.2.html&#34;&gt;release&#xA;notes&lt;/a&gt;&#xA;and&#xA;&lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.2/hadoop-project-dist/hadoop-common/release/2.8.2/CHANGES.2.8.2.html&#34;&gt;changelog&lt;/a&gt;&lt;/p&gt;</description>
+      <description>This is the first GA release in the 2.8 release line. It contains 315 bug fixes, improvments and other enhancements since 2.8.1. For major features and improvements for Apache Hadoop 2.8, please refer: overview of major changes. For details of 315 fixes, improvements, and other enhancements since the previous 2.8.1 release, please check: release notes and changelog</description>
     </item>
+    
     <item>
       <title>Release 3.0.0-beta1 available</title>
       <link>https://hadoop.apache.org/release/3.0.0-beta1.html</link>
       <pubDate>Tue, 03 Oct 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0-beta1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first beta release in the 3.0.0 release line. It consists of 576 bug fixes, improvements, and other enhancements since 3.0.0-alpha4. This is planned to be the final alpha release, with the next release being 3.0.0 GA.&lt;/p&gt;</description>
+      <description>This is the first beta release in the 3.0.0 release line. It consists of 576 bug fixes, improvements, and other enhancements since 3.0.0-alpha4. This is planned to be the final alpha release, with the next release being 3.0.0 GA.
+Please note that beta releases are API stable but come with no guarantees of quality, and are not intended for production use.
+Users are encouraged to read the overview of major changes coming in 3.</description>
     </item>
+    
     <item>
       <title>Release 2.7.4 available</title>
       <link>https://hadoop.apache.org/release/2.7.4.html</link>
       <pubDate>Fri, 04 Aug 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.7 line.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.7 line.
+Please see the Hadoop 2.7.4 Release Notes for the list of 264 bugs fixes and optimizations since the previous release 2.7.3.</description>
     </item>
+    
     <item>
       <title>Release 3.0.0-alpha4 available</title>
       <link>https://hadoop.apache.org/release/3.0.0-alpha4.html</link>
       <pubDate>Fri, 07 Jul 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0-alpha4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the fourth alpha release in the 3.0.0 release line. It consists&#xA;of 814 bug fixes, improvements, and other enhancements since&#xA;3.0.0-alpha3. This is planned to be the final alpha release, with the&#xA;next release being 3.0.0-beta1.&lt;/p&gt;</description>
+      <description>This is the fourth alpha release in the 3.0.0 release line. It consists of 814 bug fixes, improvements, and other enhancements since 3.0.0-alpha3. This is planned to be the final alpha release, with the next release being 3.0.0-beta1.
+Please note that alpha releases come with no guarantees of quality or API stability, and are not intended for production use.
+Users are encouraged to read the overview of major changes coming in 3.</description>
     </item>
+    
     <item>
       <title>Release 2.8.1 available</title>
       <link>https://hadoop.apache.org/release/2.8.1.html</link>
       <pubDate>Thu, 08 Jun 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a security release in the 2.8.0 release line. It consists of&#xA;2.8.0 plus security fixes. Users on 2.8.0 are encouraged to upgrade to&#xA;2.8.1.&lt;/p&gt;</description>
+      <description>This is a security release in the 2.8.0 release line. It consists of 2.8.0 plus security fixes. Users on 2.8.0 are encouraged to upgrade to 2.8.1.
+Please note that 2.8.x release line continues to be not yet ready for production use. Critical issues are being ironed out via testing and downstream adoption. Production users should wait for a subsequent release in the 2.8.x line.</description>
     </item>
+    
     <item>
       <title>Release 2.8.0 available</title>
       <link>https://hadoop.apache.org/release/2.8.0.html</link>
       <pubDate>Wed, 22 Mar 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.8.0 contains a number of significant features and enhancements. For major features and improvements, please refer: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.0/index.html&#34;&gt;overview of major changes&lt;/a&gt; coming in 2.8.0. For details of 2917 fixes, improvements, and new features since the previous 2.7.0 release, please check: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-commonreleasenotes.html&#34;&gt;release notes&lt;/a&gt; and &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-common/CHANGES.txt&#34;&gt;changelog&lt;/a&gt;&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.8.0 contains a number of significant features and enhancements. For major features and improvements, please refer: overview of major changes coming in 2.8.0. For details of 2917 fixes, improvements, and new features since the previous 2.7.0 release, please check: release notes and changelog
+Please note that this release is not yet ready for production use. Critical issues are being ironed out via testing and downstream adoption. Production users should wait for a 2.</description>
     </item>
+    
     <item>
       <title>Release 3.0.0-alpha2</title>
       <link>https://hadoop.apache.org/release/3.0.0-alpha2.html</link>
       <pubDate>Wed, 25 Jan 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0-alpha2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second alpha in a series of planned alphas and betas leading up to a 3.0.0 GA release. The intention is to &amp;ldquo;release early, release often&amp;rdquo; to quickly iterate on feedback collected from downstream users.&lt;/p&gt;</description>
+      <description>This is the second alpha in a series of planned alphas and betas leading up to a 3.0.0 GA release. The intention is to &amp;ldquo;release early, release often&amp;rdquo; to quickly iterate on feedback collected from downstream users.
+Please note that alpha releases come with no guarantees of quality or API stability, and are not intended for production use.
+Users are encouraged to read the overview of major changes coming in 3.</description>
     </item>
+    
     <item>
       <title>Release 2.6.5 available</title>
       <link>https://hadoop.apache.org/release/2.6.5.html</link>
       <pubDate>Sat, 08 Oct 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 2.6 line.&lt;/p&gt;</description>
+      <description>A point release for the 2.6 line.
+Please see the Hadoop 2.6.5 Release Notes for the list of 79 critical bug fixes and since the previous release 2.6.4.</description>
     </item>
+    
     <item>
       <title>Release 3.0.0-alpha1 available</title>
       <link>https://hadoop.apache.org/release/3.0.0-alpha1.html</link>
       <pubDate>Sat, 03 Sep 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0-alpha1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first alpha in a series of planned alphas and betas leading&#xA;up to a 3.0.0 GA release. The intention is to &amp;ldquo;release early, release&#xA;often&amp;rdquo; to quickly iterate on feedback collected from downstream users.&lt;/p&gt;</description>
+      <description>This is the first alpha in a series of planned alphas and betas leading up to a 3.0.0 GA release. The intention is to &amp;ldquo;release early, release often&amp;rdquo; to quickly iterate on feedback collected from downstream users.
+Please note that alpha releases come with no guarantees of quality or API stability, and are not intended for production use.
+Users are encouraged to read the overview of major changes coming in 3.</description>
     </item>
+    
     <item>
       <title>Release 2.7.3 available</title>
       <link>https://hadoop.apache.org/release/2.7.3.html</link>
       <pubDate>Fri, 26 Aug 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Please see the &lt;a href=&#34;https://hadoop.apache.org/docs/r2.7.3/hadoop-project-dist/hadoop-common/releasenotes.html&#34;&gt;Hadoop 2.7.3 Release&#xA;Notes&lt;/a&gt;&#xA;for the list of 221 bug fixes and patches since the previous release&#xA;2.7.2.&lt;/p&gt;</description>
+      <description>Please see the Hadoop 2.7.3 Release Notes for the list of 221 bug fixes and patches since the previous release 2.7.2.</description>
     </item>
+    
     <item>
       <title>Release 2.6.4 available</title>
       <link>https://hadoop.apache.org/release/2.6.4.html</link>
       <pubDate>Thu, 11 Feb 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 2.6 line.&lt;/p&gt;</description>
+      <description>A point release for the 2.6 line.
+Please see the Hadoop 2.6.4 Release Notes for the list of 46 bug fixes and patches since the previous release 2.6.3.</description>
     </item>
+    
     <item>
       <title>Release 2.7.2 (stable) available</title>
       <link>https://hadoop.apache.org/release/2.7.2.html</link>
       <pubDate>Mon, 25 Jan 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 2.7 line.&lt;/p&gt;</description>
+      <description>A point release for the 2.7 line.
+Please see the Hadoop 2.7.2 Release Notes for the list of 155 bug fixes and patches since the previous release 2.7.1.</description>
     </item>
+    
     <item>
       <title>Release 2.6.3 available</title>
       <link>https://hadoop.apache.org/release/2.6.3.html</link>
       <pubDate>Thu, 17 Dec 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.6.3 is a point release in the 2.6.x release line, and&#xA;fixes a few critical issues in 2.6.2.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.6.3 is a point release in the 2.6.x release line, and fixes a few critical issues in 2.6.2.
+Please see the Hadoop 2.6.3 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.6.2 available</title>
       <link>https://hadoop.apache.org/release/2.6.2.html</link>
       <pubDate>Wed, 28 Oct 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.6.2 is a point release in the 2.6.x release line, and&#xA;fixes a few critical issues in 2.6.1.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.6.2 is a point release in the 2.6.x release line, and fixes a few critical issues in 2.6.1.
+Please see the Hadoop 2.6.2 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.6.1 available</title>
       <link>https://hadoop.apache.org/release/2.6.1.html</link>
       <pubDate>Wed, 23 Sep 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.6.1 is a point release in the 2.6.x release line, and&#xA;fixes a lot of critical issues in 2.6.0.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.6.1 is a point release in the 2.6.x release line, and fixes a lot of critical issues in 2.6.0.
+Please see the Hadoop 2.6.1 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.7.1 (stable) available</title>
       <link>https://hadoop.apache.org/release/2.7.1.html</link>
       <pubDate>Mon, 06 Jul 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 2.7 line. This release is now considered stable.&lt;/p&gt;</description>
+      <description>A point release for the 2.7 line. This release is now considered stable.
+Please see the Hadoop 2.7.1 Release Notes for the list of 131 bug fixes and patches since the previous release 2.7.0. Please look at the 2.7.0 section below for the list of enhancements enabled by this first stable release of 2.7.x.</description>
     </item>
+    
     <item>
       <title>Release 2.7.0 available</title>
       <link>https://hadoop.apache.org/release/2.7.0.html</link>
       <pubDate>Tue, 21 Apr 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.7.0 contains a number of significant enhancements. A few&#xA;of them are noted below.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.7.0 contains a number of significant enhancements. A few of them are noted below.
+IMPORTANT notes This release drops support for JDK6 runtime and works with JDK 7+ only. This release is not yet ready for production use. Critical issues are being ironed out via testing and downstream adoption. Production users should wait for a 2.7.1/2.7.2 release. Hadoop Common HADOOP-9629 - Support Windows Azure Storage - Blob as a file system in Hadoop.</description>
     </item>
+    
     <item>
       <title>Release 2.5.2 available</title>
       <link>https://hadoop.apache.org/release/2.5.2.html</link>
       <pubDate>Wed, 19 Nov 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.5.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.5.2 is a point release in the 2.5.x release line, and&#xA;fixes a few critical issues in 2.5.1&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.5.2 is a point release in the 2.5.x release line, and fixes a few critical issues in 2.5.1</description>
     </item>
+    
     <item>
       <title>Release 2.6.0 available</title>
       <link>https://hadoop.apache.org/release/2.6.0.html</link>
       <pubDate>Tue, 18 Nov 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.6.0 contains a number of significant enhancements such&#xA;as:&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.6.0 contains a number of significant enhancements such as:
+Hadoop Common HADOOP-10433 - Key management server (beta) HADOOP-10607 - Credential provider (beta) Hadoop HDFS Heterogeneous Storage Tiers - Phase 2 HDFS-5682 - Application APIs for heterogeneous storage HDFS-7228 - SSD storage tier HDFS-5851 - Memory as a storage tier (beta) HDFS-6584 - Support for Archival Storage HDFS-6134 - Transparent data at rest encryption (beta) HDFS-2856 - Operating secure DataNode without requiring root access HDFS-6740 - Hot swap drive: support add/remove data node volumes without restarting data node (beta) HDFS-6606 - AES support for faster wire encryption Hadoop YARN YARN-896 - Support for long running services in YARN YARN-913 - Service Registry for applications YARN-666 - Support for rolling upgrades YARN-556 - Work-preserving restarts of ResourceManager YARN-1336 - Container-preserving restart of NodeManager YARN-796 - Support node labels during scheduling YARN-1051 - Support for time-based resource reservations in Capacity Scheduler (beta) YARN-1964 - Support running of applications natively in Docker containers (alpha) Please see the Hadoop 2.</description>
     </item>
+    
     <item>
       <title>Release 2.5.1 available</title>
       <link>https://hadoop.apache.org/release/2.5.1.html</link>
       <pubDate>Fri, 12 Sep 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.5.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.5.1 is a point release in the 2.5.x release line, and&#xA;fixes a few release issues with 2.5.0.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.5.1 is a point release in the 2.5.x release line, and fixes a few release issues with 2.5.0.</description>
     </item>
+    
     <item>
       <title>Release 2.5.0 available</title>
       <link>https://hadoop.apache.org/release/2.5.0.html</link>
       <pubDate>Mon, 11 Aug 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.5.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.5.0 is a minor release in the 2.x release line.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.5.0 is a minor release in the 2.x release line.
+The release includes the following major features and improvements:
+Authentication improvements when using an HTTP proxy server. A new Hadoop Metrics sink that allows writing directly to Graphite. Specification for Hadoop Compatible Filesystem effort. Support for POSIX-style filesystem extended attributes. OfflineImageViewer to browse an fsimage via the WebHDFS API. Supportability improvements and bug fixes to the NFS gateway.</description>
     </item>
+    
     <item>
       <title>Release 2.4.1 available</title>
       <link>https://hadoop.apache.org/release/2.4.1.html</link>
       <pubDate>Mon, 30 Jun 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.4.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.4.1 is a bug-fix release for the stable 2.4.x line.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.4.1 is a bug-fix release for the stable 2.4.x line.
+There is also a security bug fix in this minor release.
+CVE-2014-0229: Add privilege checks to HDFS admin sub-commands refreshNamenodes, deleteBlockPool and shutdownDatanode. Users are encouraged to immediately move to 2.4.1.
+Please see the Hadoop 2.4.1 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.11 available</title>
       <link>https://hadoop.apache.org/release/0.23.11.html</link>
       <pubDate>Fri, 27 Jun 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.11.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.11 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.4.0 available</title>
       <link>https://hadoop.apache.org/release/2.4.0.html</link>
       <pubDate>Mon, 07 Apr 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.4.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.4.0 contains a number of significant enhancements such&#xA;as:&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.4.0 contains a number of significant enhancements such as:
+Support for Access Control Lists in HDFS Native support for Rolling Upgrades in HDFS Usage of protocol-buffers for HDFS FSImage for smooth operational upgrades Complete HTTPS support in HDFS Support for Automatic Failover of the YARN ResourceManager Enhanced support for new applications on YARN with Application History Server and Application Timeline Server Support for strong SLAs in YARN CapacityScheduler via Preemption Please see the Hadoop 2.</description>
     </item>
+    
     <item>
       <title>Release 2.3.0 available</title>
       <link>https://hadoop.apache.org/release/2.3.0.html</link>
       <pubDate>Thu, 20 Feb 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.3.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.3.0 contains a number of significant enhancements such&#xA;as:&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.3.0 contains a number of significant enhancements such as:
+Support for Heterogeneous Storage hierarchy in HDFS. In-memory cache for HDFS data with centralized administration and management. Simplified distribution of MapReduce binaries via HDFS in YARN Distributed Cache. Please see the Hadoop 2.3.0 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.10 available</title>
       <link>https://hadoop.apache.org/release/0.23.10.html</link>
       <pubDate>Wed, 11 Dec 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.10.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.10 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.2.0 available</title>
       <link>https://hadoop.apache.org/release/2.2.0.html</link>
       <pubDate>Tue, 15 Oct 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.2.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.2.0 is the &lt;strong&gt;GA&lt;/strong&gt; release of Apache Hadoop 2.x.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.2.0 is the GA release of Apache Hadoop 2.x.
+Users are encouraged to immediately move to 2.2.0 since this release is significantly more stable and is guaranteed to remain compatible in terms of both APIs and protocols.
+To recap, this release has a number of significant highlights compared to Hadoop 1.x:
+YARN - A general purpose resource management system for Hadoop to allow MapReduce and other other data processing frameworks and services High Availability for HDFS HDFS Federation HDFS Snapshots NFSv3 access to data in HDFS Support for running Hadoop on Microsoft Windows Binary Compatibility for MapReduce applications built on hadoop-1.</description>
     </item>
+    
     <item>
       <title>Release 2.1.1-beta available</title>
       <link>https://hadoop.apache.org/release/2.1.1-beta.html</link>
       <pubDate>Mon, 23 Sep 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.1.1-beta.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.1.1-beta is a bug-fix version of the beta release of&#xA;Apache Hadoop 2.x.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.1.1-beta is a bug-fix version of the beta release of Apache Hadoop 2.x.
+Please see the Hadoop 2.1.1-beta Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.1.0-beta available</title>
       <link>https://hadoop.apache.org/release/2.1.0-beta.html</link>
       <pubDate>Sun, 25 Aug 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.1.0-beta.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.1.0-beta is the &lt;strong&gt;beta&lt;/strong&gt; release of Apache Hadoop 2.x.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.1.0-beta is the beta release of Apache Hadoop 2.x.
+Users are encouraged to immediately move to 2.1.0-beta since this release is significantly more stable and has completley whetted set of APIs and wire-protocols for future compatibility.
+In addition, this release has a number of other significant highlights:
+HDFS Snapshots Support for running Hadoop on Microsoft Windows YARN API stabilization Binary Compatibility for MapReduce applications built on hadoop-1.x Substantial amount of integration testing with rest of projects in the ecosystem Please see the Hadoop 2.</description>
     </item>
+    
     <item>
       <title>Release 2.0.6-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.6-alpha.html</link>
       <pubDate>Fri, 23 Aug 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.6-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release delivers a number of critical bug-fixes for hadoop-2.x&#xA;uncovered during integration testing of previous release.&lt;/p&gt;</description>
+      <description>This release delivers a number of critical bug-fixes for hadoop-2.x uncovered during integration testing of previous release.
+Please see the Hadoop 2.0.6-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.2.1 (stable) available</title>
       <link>https://hadoop.apache.org/release/1.2.1.html</link>
       <pubDate>Thu, 01 Aug 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.2.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 1.2 line. This release is now considered stable.&lt;/p&gt;</description>
+      <description>A point release for the 1.2 line. This release is now considered stable.
+Please see the Hadoop 1.2.1 Release Notes for the list of 18 bug fixes and patches since the previous release 1.2.0.</description>
     </item>
+    
     <item>
       <title>Release 0.23.9 available</title>
       <link>https://hadoop.apache.org/release/0.23.9.html</link>
       <pubDate>Mon, 08 Jul 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.9.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.9 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.0.5-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.5-alpha.html</link>
       <pubDate>Thu, 06 Jun 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.5-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release delivers a number of critical bug-fixes for hadoop-2.x&#xA;uncovered during integration testing of previous release.&lt;/p&gt;</description>
+      <description>This release delivers a number of critical bug-fixes for hadoop-2.x uncovered during integration testing of previous release.
+Please see the Hadoop 2.0.5-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.8 available</title>
       <link>https://hadoop.apache.org/release/0.23.8.html</link>
       <pubDate>Wed, 05 Jun 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.8.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.8 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.2.0 available</title>
       <link>https://hadoop.apache.org/release/1.2.0.html</link>
       <pubDate>Mon, 13 May 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.2.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a beta release for version 1.2.&lt;/p&gt;</description>
+      <description>This is a beta release for version 1.2.
+This release delivers over 200 enhancements and bug-fixes, compared to the previous 1.1.2 release. Major enhancements include:
+DistCp v2 backported Web services for JobTracker WebHDFS enhancements Extensions of task placement and replica placement policy interfaces Offline Image Viewer backported Namenode more robust in case of edit log corruption Add NodeGroups level to NetworkTopology Add &amp;ldquo;unset&amp;rdquo; to Configuration API Please see the Hadoop 1.</description>
     </item>
+    
     <item>
       <title>Release 2.0.4-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.4-alpha.html</link>
       <pubDate>Thu, 25 Apr 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.4-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release delivers a number of critical bug-fixes for hadoop-2.x&#xA;uncovered during integration testing.&lt;/p&gt;</description>
+      <description>This release delivers a number of critical bug-fixes for hadoop-2.x uncovered during integration testing.
+Please see the Hadoop 2.0.4-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.7 available</title>
       <link>https://hadoop.apache.org/release/0.23.7.html</link>
       <pubDate>Thu, 18 Apr 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.7.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.7 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.1.2 available</title>
       <link>https://hadoop.apache.org/release/1.1.2.html</link>
       <pubDate>Fri, 15 Feb 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.1.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Point release for the 1.1.X line. Bug fixes and improvements, as&#xA;documented in the &lt;a href=&#34;https://hadoop.apache.org/docs/r1.1.2/releasenotes.html&#34;&gt;Hadoop 1.1.2 Release&#xA;Notes&lt;/a&gt;.&lt;/p&gt;</description>
+      <description>Point release for the 1.1.X line. Bug fixes and improvements, as documented in the Hadoop 1.1.2 Release Notes.</description>
     </item>
+    
     <item>
       <title>Release 2.0.3-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.3-alpha.html</link>
       <pubDate>Thu, 14 Feb 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.3-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the latest (alpha) version in the hadoop-2.x series.&lt;/p&gt;</description>
+      <description>This is the latest (alpha) version in the hadoop-2.x series.
+This release delivers significant major features and stability over previous releases in hadoop-2.x series:
+QJM for HDFS HA for NameNode Multi-resource scheduling (CPU and memory) for YARN YARN ResourceManager Restart Significant stability at scale for YARN (over 30,000 nodes and 14 million applications so far, at time of release) This release, like previous releases in hadoop-2.x series is still considered alpha primarily since some of APIs aren&amp;rsquo;t fully-baked and we expect some churn in future.</description>
     </item>
+    
     <item>
       <title>Release 0.23.6 available</title>
       <link>https://hadoop.apache.org/release/0.23.6.html</link>
       <pubDate>Thu, 07 Feb 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.6.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.6 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.1.1 available</title>
       <link>https://hadoop.apache.org/release/1.1.1.html</link>
       <pubDate>Sat, 01 Dec 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.1.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Point release for the 1.1.X line. Bug fixes and improvements, as&#xA;documented in the &lt;a href=&#34;https://hadoop.apache.org/docs/r1.1.1/releasenotes.html&#34;&gt;Hadoop 1.1.1 Release&#xA;Notes&lt;/a&gt;.&lt;/p&gt;</description>
+      <description>Point release for the 1.1.X line. Bug fixes and improvements, as documented in the Hadoop 1.1.1 Release Notes.</description>
     </item>
+    
     <item>
       <title>Release 0.23.5 available</title>
       <link>https://hadoop.apache.org/release/0.23.5.html</link>
       <pubDate>Wed, 28 Nov 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.5 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.4 available</title>
       <link>https://hadoop.apache.org/release/0.23.4.html</link>
       <pubDate>Mon, 15 Oct 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Most notably this release now&#xA;incluses support for upgrading a 1.X HDFS cluster with append/synch&#xA;enabled.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Most notably this release now incluses support for upgrading a 1.X HDFS cluster with append/synch enabled.
+Please see the Hadoop 0.23.4 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.1.0 available</title>
       <link>https://hadoop.apache.org/release/1.1.0.html</link>
       <pubDate>Sat, 13 Oct 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.1.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a beta release for version 1.1.&lt;/p&gt;</description>
+      <description>This is a beta release for version 1.1.
+This release has approximately 135 enhancements and bug fixes compared to Hadoop-1.0.4, including:
+Many performance improvements in HDFS, backported from trunk Improvements in Security to use SPNEGO instead of Kerberized SSL for HTTP transactions Lower default minimum heartbeat for task trackers from 3 sec to 300msec to increase job throughput on small clusters Port of Gridmix v3 Set MALLOC_ARENA_MAX in hadoop-config.sh to resolve problems with glibc in RHEL-6 Splittable bzip2 files Of course it also has the same security fix as release 1.</description>
     </item>
+    
     <item>
       <title>Release 1.0.4 available</title>
       <link>https://hadoop.apache.org/release/1.0.4.html</link>
       <pubDate>Fri, 12 Oct 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a Security Patch release for version 1.0.&lt;/p&gt;</description>
+      <description>This is a Security Patch release for version 1.0.
+There are four bug fixes and feature enhancements in this minor release:
+Security issue CVE-2012-4449: Hadoop tokens use a 20-bit secret HADOOP-7154 - set MALLOC_ARENA_MAX in hadoop-config.sh to resolve problems with glibc in RHEL-6 HDFS-3652 - FSEditLog failure removes the wrong edit stream when storage dirs have same name MAPREDUCE-4399 - Fix (up to 3x) performance regression in shuffle Please see the Hadoop 1.</description>
     </item>
+    
     <item>
       <title>Release 2.0.2-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.2-alpha.html</link>
       <pubDate>Tue, 09 Oct 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.2-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second (alpha) version in the hadoop-2.x series.&lt;/p&gt;</description>
+      <description>This is the second (alpha) version in the hadoop-2.x series.
+This delivers significant enhancements to HDFS HA. Also it has a significantly more stable version of YARN which, at the time of release, has already been deployed on a 2000 node cluster.
+Please see the Hadoop 2.0.2-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.3 available</title>
       <link>https://hadoop.apache.org/release/0.23.3.html</link>
       <pubDate>Mon, 17 Sep 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains YARN and MRv2 but does not have Name Node High&#xA;Avalability&lt;/p&gt;</description>
+      <description>This release contains YARN and MRv2 but does not have Name Node High Avalability
+Please see the Hadoop 0.23.3 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.0.1-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.1-alpha.html</link>
       <pubDate>Thu, 26 Jul 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.1-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains important security fixes over hadoop-2.0.0-alpha.&lt;/p&gt;</description>
+      <description>This release contains important security fixes over hadoop-2.0.0-alpha.
+Please see the Hadoop 2.0.1-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.0.0-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.0-alpha.html</link>
       <pubDate>Wed, 23 May 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.0-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first (alpha) version in the hadoop-2.x series.&lt;/p&gt;</description>
+      <description>This is the first (alpha) version in the hadoop-2.x series.
+This delivers significant major features over the currently stable hadoop-1.x series including:
+HDFS HA for NameNode (manual failover) YARN aka NextGen MapReduce HDFS Federation Performance Wire-compatibility for both HDFS and YARN/MapReduce (using protobufs) Please see the Hadoop 2.0.0-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.0.3 available</title>
       <link>https://hadoop.apache.org/release/1.0.3.html</link>
       <pubDate>Wed, 16 May 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a bug fix release for version 1.0.&lt;/p&gt;</description>
+      <description>This is a bug fix release for version 1.0.
+Bug fixes and feature enhancements in this minor release include:
+4 patches in support of non-Oracle JDKs several patches to clean up error handling and log messages various production issue fixes Please see the Hadoop 1.0.3 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.0.2 available</title>
       <link>https://hadoop.apache.org/release/1.0.2.html</link>
       <pubDate>Tue, 03 Apr 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a bug fix release for version 1.0.&lt;/p&gt;</description>
+      <description>This is a bug fix release for version 1.0.
+Bug fixes and feature enhancements in this minor release include:
+Snappy compressor/decompressor is available Occassional deadlock in metrics serving thread fixed 64-bit secure datanodes failed to start, now fixed Changed package names for 64-bit rpm/debs to use &amp;ldquo;.x86_64.&amp;rdquo; instead of &amp;ldquo;.amd64.&amp;rdquo; Please see the Hadoop 1.0.2 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.0.1 available</title>
       <link>https://hadoop.apache.org/release/1.0.1.html</link>
       <pubDate>Sat, 10 Mar 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a bug fix release for version 1.0. This release is now&#xA;considered stable, replacing the long-standing 0.20.203.&lt;/p&gt;</description>
+      <description>This is a bug fix release for version 1.0. This release is now considered stable, replacing the long-standing 0.20.203.
+Bug fixes in this minor release include:
+Added hadoop-client and hadoop-minicluster artifacts for ease of client install and testing Support run-as-user in non-secure mode Better compatibility with Ganglia, HBase, and Sqoop Please see the Hadoop 1.0.1 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.23.1 available</title>
       <link>https://hadoop.apache.org/release/0.23.1.html</link>
       <pubDate>Mon, 27 Feb 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second alpha version of the hadoop-0.23 major release after&#xA;the first alpha 0.23.0. This release has significant improvements&#xA;compared to 0.23.0 but should still be considered as alpha-quality and&#xA;not for production use.&lt;/p&gt;</description>
+      <description>This is the second alpha version of the hadoop-0.23 major release after the first alpha 0.23.0. This release has significant improvements compared to 0.23.0 but should still be considered as alpha-quality and not for production use.
+hadoop-0.23.1 contains several major advances from 0.23.0:
+Lots of bug fixes and improvements in both HDFS and MapReduce Major performance work to make this release either match or exceed performance of Hadoop-1 in most aspects of both HDFS and MapReduce.</description>
     </item>
+    
     <item>
       <title>release 1.0.0 available</title>
       <link>https://hadoop.apache.org/release/1.0.0.html</link>
       <pubDate>Tue, 27 Dec 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;After six years of gestation, Hadoop reaches 1.0.0! This release is from&#xA;the 0.20-security code line, and includes support for:&lt;/p&gt;</description>
+      <description>After six years of gestation, Hadoop reaches 1.0.0! This release is from the 0.20-security code line, and includes support for:
+security HBase (append/hsynch/hflush, and security) webhdfs (with full support for security) performance enhanced access to local files for HBase other performance enhancements, bug fixes, and features Please see the complete Hadoop 1.0.0 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.22.0 available</title>
       <link>https://hadoop.apache.org/release/0.22.0.html</link>
       <pubDate>Sat, 10 Dec 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.22.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many bug fixes and optimizations compared to its&#xA;predecessor 0.21.0. See the &lt;a href=&#34;https://hadoop.apache.org/docs/r0.22.0/releasenotes.html&#34;&gt;Hadoop 0.22.0 Release&#xA;Notes&lt;/a&gt; for&#xA;details. Alternatively, you can look at the complete &lt;a href=&#34;https://hadoop.apache.org/docs/r0.22.0/changes.html&#34;&gt;change log for&#xA;this release&lt;/a&gt;&lt;/p&gt;</description>
+      <description>This release contains many bug fixes and optimizations compared to its predecessor 0.21.0. See the Hadoop 0.22.0 Release Notes for details. Alternatively, you can look at the complete change log for this release
+Notes:
+The following features are not supported in Hadoop 0.22.0.
+Security. Latest optimizations of the MapReduce framework introduced in the Hadoop 0.20.security line of releases. Disk-fail-in-place. JMX-based metrics v2. Hadoop 0.22.0 features
+HBase support with hflush and hsync.</description>
     </item>
+    
     <item>
       <title>release 0.23.0 available</title>
       <link>https://hadoop.apache.org/release/0.23.0.html</link>
       <pubDate>Fri, 11 Nov 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the alpha version of the hadoop-0.23 major release. This is the&#xA;first release we&amp;rsquo;ve made off Apache Hadoop trunk in a long while. This&#xA;release is alpha-quality and not yet ready for serious use.&lt;/p&gt;</description>
+      <description>This is the alpha version of the hadoop-0.23 major release. This is the first release we&amp;rsquo;ve made off Apache Hadoop trunk in a long while. This release is alpha-quality and not yet ready for serious use.
+hadoop-0.23 contains several major advances:
+HDFS Federation NextGen MapReduce (YARN) It also has several major performance improvements to both HDFS and MapReduce.
+See the Hadoop 0.23.0 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.20.205.0 available</title>
       <link>https://hadoop.apache.org/release/0.20.205.0.html</link>
       <pubDate>Mon, 17 Oct 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.205.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains improvements, new features, bug fixes and&#xA;optimizations. This release includes rpms and debs, all duly checksummed&#xA;and securely signed.&lt;/p&gt;</description>
+      <description>This release contains improvements, new features, bug fixes and optimizations. This release includes rpms and debs, all duly checksummed and securely signed.
+See the Hadoop 0.20.205.0 Release Notes for details. Alternatively, you can look at the complete change log for this release.
+Notes:
+This release includes a merge of append/hsynch/hflush capabilities from 0.20-append branch, to support HBase in secure mode. This release includes the new webhdfs file system, but webhdfs write calls currently fail in secure mode.</description>
     </item>
+    
     <item>
       <title>release 0.20.204.0 available</title>
       <link>https://hadoop.apache.org/release/0.20.204.0.html</link>
       <pubDate>Mon, 05 Sep 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.204.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains improvements, new features, bug fixes and&#xA;optimizations. This release includes rpms and debs for the first time.&lt;/p&gt;</description>
+      <description> This release contains improvements, new features, bug fixes and optimizations. This release includes rpms and debs for the first time.
+See the Hadoop 0.20.204.0 Release Notes for details. Alternatively, you can look at the complete change log for this release.
+Notes:
+The RPMs don&amp;rsquo;t work with security turned on. (HADOOP-7599) The NameNode&amp;rsquo;s edit log needs to be merged into the image via put the NameNode into safe mode run dfsadmin savenamespace command perform a normal upgrade </description>
     </item>
+    
     <item>
       <title>release 0.20.203.0 available</title>
       <link>https://hadoop.apache.org/release/0.20.203.0.html</link>
       <pubDate>Wed, 11 May 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.203.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations. It is stable and has been deployed in large (4,500&#xA;machine) production clusters.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations. It is stable and has been deployed in large (4,500 machine) production clusters.
+See the Hadoop 0.20.203.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>Apache Hadoop takes top prize at Media Guardian Innovation Awards</title>
       <link>https://hadoop.apache.org/news/2011-03-xx-award.html</link>
       <pubDate>Thu, 31 Mar 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2011-03-xx-award.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Described by the judging panel as a &amp;ldquo;Swiss army knife of the 21st&#xA;century&amp;rdquo;, Apache Hadoop picked up the &lt;em&gt;innovator of the year&lt;/em&gt; award for&#xA;having the potential to change the face of media innovations.&lt;/p&gt;</description>
+      <description>Described by the judging panel as a &amp;ldquo;Swiss army knife of the 21st century&amp;rdquo;, Apache Hadoop picked up the innovator of the year award for having the potential to change the face of media innovations.
+See The Guardian web site</description>
     </item>
+    
     <item>
       <title>ZooKeeper Graduates</title>
       <link>https://hadoop.apache.org/news/2011-01-xx-zookeeper.html</link>
       <pubDate>Sun, 30 Jan 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2011-01-xx-zookeeper.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop&amp;rsquo;s ZooKeeper subproject has graduated to become a top-level Apache&#xA;project.&lt;/p&gt;</description>
+      <description>Hadoop&amp;rsquo;s ZooKeeper subproject has graduated to become a top-level Apache project.
+Apache ZooKeeper can now be found at http://zookeeper.apache.org/</description>
     </item>
+    
     <item>
       <title>Hive and Pig Graduate</title>
       <link>https://hadoop.apache.org/news/2010-10-xx-hive-pig.html</link>
       <pubDate>Sat, 30 Oct 2010 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2010-10-xx-hive-pig.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop&amp;rsquo;s Hive and Pig subprojects have graduated to become top-level&#xA;Apache projects.&lt;/p&gt;</description>
+      <description>Hadoop&amp;rsquo;s Hive and Pig subprojects have graduated to become top-level Apache projects.
+Apache Hive can now be found at http://hive.apache.org/
+Pig can now be found at http://pig.apache.org/</description>
     </item>
+    
     <item>
       <title>release 0.21.0 available</title>
       <link>https://hadoop.apache.org/release/0.21.0.html</link>
       <pubDate>Mon, 23 Aug 2010 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.21.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations. It has not undergone testing at scale and should not be&#xA;considered stable or suitable for production. This release is being&#xA;classified as a minor release, which means that it should be API&#xA;compatible with 0.20.2.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations. It has not undergone testing at scale and should not be considered stable or suitable for production. This release is being classified as a minor release, which means that it should be API compatible with 0.20.2.
+See the Hadoop 0.21.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>Avro and HBase Graduate</title>
       <link>https://hadoop.apache.org/news/2010-05-xx-avro-hbase.html</link>
       <pubDate>Mon, 31 May 2010 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2010-05-xx-avro-hbase.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop&amp;rsquo;s Avro and HBase subprojects have graduated to become top-level&#xA;Apache projects.&lt;/p&gt;</description>
+      <description>Hadoop&amp;rsquo;s Avro and HBase subprojects have graduated to become top-level Apache projects.
+Apache Avro can now be found at http://avro.apache.org/
+Apache HBase can now be found at http://hbase.apache.org/</description>
     </item>
+    
     <item>
       <title>release 0.20.2 available</title>
       <link>https://hadoop.apache.org/release/0.20.2.html</link>
       <pubDate>Fri, 26 Feb 2010 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.20.2 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.20.1 available</title>
       <link>https://hadoop.apache.org/release/0.20.1.html</link>
       <pubDate>Mon, 14 Sep 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.20.1 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>New Hadoop Subprojects</title>
       <link>https://hadoop.apache.org/news/2009-07-xx-subprojects.html</link>
       <pubDate>Fri, 31 Jul 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2009-07-xx-subprojects.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop is getting bigger!&lt;/p&gt;</description>
+      <description>Hadoop is getting bigger!
+Hadoop Core is renamed Hadoop Common. MapReduce and the Hadoop Distributed File System (HDFS) are now separate subprojects. Avro and Chukwa are new Hadoop subprojects. See the summary descriptions for all subprojects above. Visit the individual sites for more detailed information.</description>
     </item>
+    
     <item>
       <title>release 0.19.2 available</title>
       <link>https://hadoop.apache.org/release/0.19.2.html</link>
       <pubDate>Thu, 23 Jul 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.19.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.19.2 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.20.0 available</title>
       <link>https://hadoop.apache.org/release/0.20.0.html</link>
       <pubDate>Wed, 22 Apr 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.20.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>ApacheCon EU</title>
       <link>https://hadoop.apache.org/news/2009-03-xx-apachecon-eu.html</link>
       <pubDate>Tue, 31 Mar 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2009-03-xx-apachecon-eu.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;In case you missed it&amp;hellip;. &lt;a href=&#34;http://www.eu.apachecon.com/c/aceu2009/&#34;&gt;ApacheCon Europe&#xA;2009&lt;/a&gt;&lt;/p&gt;</description>
+      <description>In case you missed it&amp;hellip;. ApacheCon Europe 2009</description>
     </item>
+    
     <item>
       <title>release 0.19.1 available</title>
       <link>https://hadoop.apache.org/release/0.19.1.html</link>
       <pubDate>Tue, 24 Feb 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.19.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many critical bug fixes, including &lt;strong&gt;some data&#xA;loss issues&lt;/strong&gt;. The release also introduces an &lt;strong&gt;incompatible change&lt;/strong&gt; by&#xA;disabling the file append API&#xA;(&lt;a href=&#34;http://issues.apache.org/jira/browse/HADOOP-5224&#34;&gt;HADOOP-5224&lt;/a&gt;) until&#xA;it can be stabilized.&lt;/p&gt;</description>
+      <description>This release contains many critical bug fixes, including some data loss issues. The release also introduces an incompatible change by disabling the file append API (HADOOP-5224) until it can be stabilized.
+See the Hadoop 0.19.1 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.18.3 available</title>
       <link>https://hadoop.apache.org/release/0.18.3.html</link>
       <pubDate>Thu, 29 Jan 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.18.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains many critical bug fixes.
+See the Hadoop 0.18.3 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>ApacheCon US 2008</title>
       <link>https://hadoop.apache.org/news/2008-11-xx-apachecon.html</link>
       <pubDate>Sun, 30 Nov 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2008-11-xx-apachecon.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;In case you missed it&amp;hellip;. &lt;a href=&#34;http://us.apachecon.com/c/acus2008/&#34;&gt;ApacheCon US 2008&lt;/a&gt;&lt;/p&gt;</description>
+      <description>In case you missed it&amp;hellip;. ApacheCon US 2008</description>
     </item>
+    
     <item>
       <title>release 0.19.0 available</title>
       <link>https://hadoop.apache.org/release/0.19.0.html</link>
       <pubDate>Fri, 21 Nov 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.19.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.19.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.18.2 available</title>
       <link>https://hadoop.apache.org/release/0.18.2.html</link>
       <pubDate>Mon, 03 Nov 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.18.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.18.2 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.18.1 available</title>
       <link>https://hadoop.apache.org/release/0.18.1.html</link>
       <pubDate>Wed, 17 Sep 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.18.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.18.1 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.18.0 available</title>
       <link>https://hadoop.apache.org/release/0.18.0.html</link>
       <pubDate>Fri, 22 Aug 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.18.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.18.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.17.2 available</title>
       <link>https://hadoop.apache.org/release/0.17.2.html</link>
       <pubDate>Tue, 19 Aug 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.17.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.17.2 Notes for details.</description>
     </item>
+    
     <item>
       <title>July 2008 - Hadoop Wins Terabyte Sort Benchmark</title>
       <link>https://hadoop.apache.org/news/2008-07-xx-terabyte-sort.html</link>
       <pubDate>Thu, 31 Jul 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2008-07-xx-terabyte-sort.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;&lt;a href=&#34;http://developer.yahoo.com/blogs/hadoop/2008/07/apache_hadoop_wins_terabyte_sort_benchmark.html&#34;&gt;Hadoop Wins Terabyte Sort&#xA;Benchmark&lt;/a&gt;:&#xA;One of Yahoo&amp;rsquo;s Hadoop clusters sorted 1 terabyte of data in 209 seconds,&#xA;which beat the previous record of 297 seconds in the annual general&#xA;purpose (Daytona) &lt;a href=&#34;http://sortbenchmark.org/&#34;&gt;terabyte sort benchmark&lt;/a&gt;.&#xA;This is the first time that either a Java or an open source program has&#xA;won.&lt;/p&gt;</description>
+      <description>Hadoop Wins Terabyte Sort Benchmark: One of Yahoo&amp;rsquo;s Hadoop clusters sorted 1 terabyte of data in 209 seconds, which beat the previous record of 297 seconds in the annual general purpose (Daytona) terabyte sort benchmark. This is the first time that either a Java or an open source program has won.</description>
     </item>
+    
     <item>
       <title>release 0.17.1 available</title>
       <link>https://hadoop.apache.org/release/0.17.1.html</link>
       <pubDate>Mon, 23 Jun 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.17.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.17.1 Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.17.0 available</title>
       <link>https://hadoop.apache.org/release/0.17.0.html</link>
       <pubDate>Tue, 20 May 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.17.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.17.0 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.16.4 available</title>
       <link>https://hadoop.apache.org/release/0.16.4.html</link>
       <pubDate>Mon, 05 May 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes 4 critical bugs in release 0.16.3.&lt;/p&gt;</description>
+      <description>This release fixes 4 critical bugs in release 0.16.3.</description>
     </item>
+    
     <item>
       <title>release 0.16.3 available</title>
       <link>https://hadoop.apache.org/release/0.16.3.html</link>
       <pubDate>Wed, 16 Apr 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.16.2.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.16.2.</description>
     </item>
+    
     <item>
       <title>release 0.16.2 available</title>
       <link>https://hadoop.apache.org/release/0.16.2.html</link>
       <pubDate>Wed, 02 Apr 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.16.1.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.16.1.
+HBase has been removed from this release. HBase releases are now maintained at https://hadoop.apache.org/hbase/</description>
     </item>
+    
     <item>
       <title>release 0.16.1 available</title>
       <link>https://hadoop.apache.org/release/0.16.1.html</link>
       <pubDate>Thu, 13 Mar 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.16.0.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.16.0.
+HBase releases are now maintained at https://hadoop.apache.org/hbase/</description>
     </item>
+    
     <item>
       <title>release 0.16.0 available</title>
       <link>https://hadoop.apache.org/release/0.16.0.html</link>
       <pubDate>Thu, 07 Feb 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the release notes (above) for details.
+When upgrading an existing HDFS filesystem to a 0.16.x release from an earlier release, you should first start HDFS with &amp;lsquo;bin/start-dfs.sh -upgrade&amp;rsquo;. See the Hadoop Upgrade page for details.</description>
     </item>
+    
     <item>
       <title>release 0.15.3 available</title>
       <link>https://hadoop.apache.org/release/0.15.3.html</link>
       <pubDate>Fri, 18 Jan 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.15.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.15.3.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.15.3.</description>
     </item>
+    
     <item>
       <title>release 0.15.2 available</title>
       <link>https://hadoop.apache.org/release/0.15.2.html</link>
       <pubDate>Wed, 02 Jan 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.15.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.15.1.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.15.1.</description>
     </item>
+    
     <item>
       <title>release 0.15.1 available</title>
       <link>https://hadoop.apache.org/release/0.15.1.html</link>
       <pubDate>Tue, 27 Nov 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.15.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.15.0.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.15.0.</description>
     </item>
+    
     <item>
       <title>release 0.14.4 available</title>
       <link>https://hadoop.apache.org/release/0.14.4.html</link>
       <pubDate>Mon, 26 Nov 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.14.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.14.3.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.14.3.</description>
     </item>
+    
     <item>
       <title>release 0.15.0 available</title>
       <link>https://hadoop.apache.org/release/0.15.0.html</link>
       <pubDate>Mon, 29 Oct 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.15.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+Notably, this contains the first working version of HBase.
+See the release notes (above) for details.
+When upgrading an existing HDFS filesystem to a 0.15.x release from an earlier release, you should first start HDFS with &amp;lsquo;bin/start-dfs.sh -upgrade&amp;rsquo;. See the Hadoop Upgrade page for details.</description>
     </item>
+    
     <item>
       <title>release 0.14.3 available</title>
       <link>https://hadoop.apache.org/release/0.14.3.html</link>
       <pubDate>Fri, 19 Oct 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.14.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.14.2.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.14.2.</description>
     </item>
+    
     <item>
       <title>release 0.14.1 available</title>
       <link>https://hadoop.apache.org/release/0.14.1.html</link>
       <pubDate>Tue, 04 Sep 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.14.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;New features in release 0.14 include:&lt;/p&gt;</description>
+      <description>New features in release 0.14 include:
+Better checksums in HDFS. Checksums are no longer stored in parallel HDFS files, but are stored directly by datanodes alongside blocks. This is more efficient for the namenode and also improves data integrity. Pipes: A C++ API for MapReduce Eclipse Plugin, including HDFS browsing, job monitoring, etc. File modification times in HDFS. There are many other improvements, bug fixes, optimizations and new features. Performance and reliability are better than ever.</description>
     </item>
+    
     <item>
       <title>Apache Hadoop Release Versioning</title>
       <link>https://hadoop.apache.org/versioning.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/versioning.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;h2 id=&#34;background&#34;&gt;Background&lt;/h2&gt;&#xA;&lt;p&gt;Apache Hadoop uses a version format of&#xA;&lt;strong&gt;&amp;lt;major&amp;gt;.&amp;lt;minor&amp;gt;.&amp;lt;maintenance&amp;gt;&lt;/strong&gt;, where each version&#xA;component is a numeric value. Versions can also have additional suffixes&#xA;like &lt;em&gt;&amp;quot;-alpha2&amp;quot;&lt;/em&gt; or &lt;em&gt;&amp;quot;-beta1&amp;quot;&lt;/em&gt;, which denote the API compatibility&#xA;guarantees and quality of the release. We use &lt;em&gt;&amp;ldquo;a.b.c&amp;rdquo;&lt;/em&gt; and &lt;em&gt;&amp;ldquo;x.y.z&amp;rdquo;&lt;/em&gt; to&#xA;denote a dotted version triplet.&lt;/p&gt;</description>
+      <description>Background Apache Hadoop uses a version format of &amp;lt;major&amp;gt;.&amp;lt;minor&amp;gt;.&amp;lt;maintenance&amp;gt;, where each version component is a numeric value. Versions can also have additional suffixes like &amp;quot;-alpha2&amp;quot; or &amp;quot;-beta1&amp;quot;, which denote the API compatibility guarantees and quality of the release. We use &amp;ldquo;a.b.c&amp;rdquo; and &amp;ldquo;x.y.z&amp;rdquo; to denote a dotted version triplet.
+Major versions are used to introduce substantial, potentially incompatible, changes. Examples of this include the replacement of MapReduce 1 with YARN and MapReduce 2 in Hadoop 2, and the required Java runtime version from JDK7 to JDK8 in Hadoop 3.</description>
     </item>
+    
     <item>
       <title>Apache Hadoop® Releases</title>
       <link>https://hadoop.apache.org/releases.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/releases.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;h2 id=&#34;to-verify-apache-hadoop-releases-using-gpg&#34;&gt;To verify Apache Hadoop® releases using GPG:&lt;/h2&gt;&#xA;&lt;ol&gt;&#xA;&lt;li&gt;Download the release hadoop-X.Y.Z-src.tar.gz from a &lt;a href=&#34;https://www.apache.org/dyn/closer.cgi/hadoop/common&#34;&gt;mirror&#xA;site&lt;/a&gt;.&lt;/li&gt;&#xA;&lt;li&gt;Download the signature file hadoop-X.Y.Z-src.tar.gz.asc from&#xA;&lt;a href=&#34;https://downloads.apache.org/hadoop/common/&#34;&gt;Apache&lt;/a&gt;.&lt;/li&gt;&#xA;&lt;li&gt;Download the &lt;a href=&#34;https://downloads.apache.org/hadoop/common/KEYS&#34;&gt;Hadoop&#xA;KEYS&lt;/a&gt; file.&lt;/li&gt;&#xA;&lt;li&gt;gpg &amp;ndash;import KEYS&lt;/li&gt;&#xA;&lt;li&gt;gpg &amp;ndash;verify hadoop-X.Y.Z-src.tar.gz.asc&lt;/li&gt;&#xA;&lt;/ol&gt;&#xA;&lt;h2 id=&#34;to-perform-a-quick-check-using-sha-512&#34;&gt;To perform a quick check using SHA-512:&lt;/h2&gt;&#xA;&lt;ol&gt;&#xA;&lt;li&gt;Download the release hadoop-X.Y.Z-src.tar.gz from a &lt;a href=&#34;https://www.apache.org/dyn/closer.cgi/hadoop/common&#34;&gt;mirror&#xA;site&lt;/a&gt;.&lt;/li&gt;&#xA;&lt;li&gt;Download the checksum hadoop-X.Y.Z-src.tar.gz.sha512 or hadoop-X.Y.Z-src.tar.gz.mds from&#xA;&lt;a href=&#34;https://downloads.apache.org/hadoop/common/&#34;&gt;Apache&lt;/a&gt;.&lt;/li&gt;&#xA;&lt;li&gt;shasum -a 512 hadoop-X.Y.Z-src.tar.gz&lt;/li&gt;&#xA;&lt;/ol&gt;&#xA;&lt;p&gt;All previous releases of Apache Hadoop are available from the &lt;a href=&#34;https://archive.apache.org/dist/hadoop/common/&#34;&gt;Apache release&#xA;archive&lt;/a&gt; site.&lt;/p&gt;</description>
+      <description>To verify Apache Hadoop® releases using GPG: Download the release hadoop-X.Y.Z-src.tar.gz from a mirror site. Download the signature file hadoop-X.Y.Z-src.tar.gz.asc from Apache. Download the Hadoop KEYS file. gpg &amp;ndash;import KEYS gpg &amp;ndash;verify hadoop-X.Y.Z-src.tar.gz.asc To perform a quick check using SHA-512: Download the release hadoop-X.Y.Z-src.tar.gz from a mirror site. Download the checksum hadoop-X.Y.Z-src.tar.gz.sha512 or hadoop-X.Y.Z-src.tar.gz.mds from Apache. shasum -a 512 hadoop-X.Y.Z-src.tar.gz All previous releases of Apache Hadoop are available from the Apache release archive site.</description>
     </item>
+    
     <item>
       <title>Bylaws</title>
       <link>https://hadoop.apache.org/bylaws.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/bylaws.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This document defines the bylaws under which the Apache Hadoop project&#xA;operates. It defines the roles and responsibilities of the project, who&#xA;may vote, how voting works, how conflicts are resolved, etc.&lt;/p&gt;</description>
+      <description>This document defines the bylaws under which the Apache Hadoop project operates. It defines the roles and responsibilities of the project, who may vote, how voting works, how conflicts are resolved, etc.
+Hadoop is a project of the Apache Software Foundation. The foundation holds the trademark on the name &amp;ldquo;Hadoop&amp;rdquo; and copyright on Apache code including the code in the Hadoop codebase. The foundation FAQ explains the operation and background of the foundation.</description>
     </item>
+    
     <item>
       <title>Criteria for Committership</title>
       <link>https://hadoop.apache.org/committer_criteria.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/committer_criteria.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Committers are responsible for reviewing and integrating code changes.&#xA;The PMC votes to make a contributor a committer based on an assessment&#xA;of their contributions to the project. Contributions can be made in many&#xA;ways, and there is no one route to committership. That said, here are&#xA;the general criteria that the PMC looks for from all potential&#xA;committers:&lt;/p&gt;</description>
+      <description>Committers are responsible for reviewing and integrating code changes. The PMC votes to make a contributor a committer based on an assessment of their contributions to the project. Contributions can be made in many ways, and there is no one route to committership. That said, here are the general criteria that the PMC looks for from all potential committers:
+A history of sustained contribution to the project. This is a way for a contributor to demonstrate their expertise in an area, and thus their ability to help review and commit contributions by others in that same area.</description>
     </item>
+    
     <item>
       <title>Description</title>
       <link>https://hadoop.apache.org/description.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/description.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;&lt;img alt=&#34;hadoop-logo&#34; src=&#34;hadoop-logo.jpg&#34;&gt; Apache Hadoop&lt;/p&gt;</description>
+      <description>Apache Hadoop
+The Apache® Hadoop® project develops open-source software for reliable, scalable, distributed computing.
+The Apache Hadoop software library is a framework that allows for the distributed processing of large data sets across clusters of computers using simple programming models. It is designed to scale up from single servers to thousands of machines, each offering local computation and storage. Rather than rely on hardware to deliver high-availability, the library itself is designed to detect and handle failures at the application layer, so delivering a highly-available service on top of a cluster of computers, each of which may be prone to failures.</description>
     </item>
+    
     <item>
       <title>Hadoop CVE List</title>
       <link>https://hadoop.apache.org/cve_list.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/cve_list.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This page lists security fixes that the Hadoop PMC felt warranted a CVE. If you think something is missing from this list or if you think the set of impacted or fixed versions is incomplete then please &lt;a href=&#34;https://hadoop.apache.org/mailing_lists.html#Security&#34;&gt;ask on the Security list&lt;/a&gt;.&lt;/p&gt;</description>
+      <description>This page lists security fixes that the Hadoop PMC felt warranted a CVE. If you think something is missing from this list or if you think the set of impacted or fixed versions is incomplete then please ask on the Security list.
+CVEs are presented in most-recent-first order of announcement.
+CVE-2023-26031 Privilege escalation in Apache Haoop Yarn container-executor binary on Linux systems Relative library resolution in linux container-executor binary in Apache Hadoop 3.</description>
     </item>
+    
     <item>
       <title>Hadoop Issue Tracking</title>
       <link>https://hadoop.apache.org/issue_tracking.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/issue_tracking.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop tracks both bugs and enhancement requests using JIRA.&lt;/p&gt;</description>
+      <description>Hadoop tracks both bugs and enhancement requests using JIRA.
+We welcome input, however, before filing a request, please make sure you do the following:
+Search the Apache JIRA database. Check the users mailing lists, both by searching the archives and by asking questions. Jira subprojects:
+Hadoop Common issues are tracked in the HADOOP Jira instance. HDFS issues are tracked in the HDFS Jira instance. YARN issues are tracked in the YARN Jira instance.</description>
     </item>
+    
     <item>
       <title>Hadoop Mailing Lists</title>
       <link>https://hadoop.apache.org/mailing_lists.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/mailing_lists.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;h2 id=&#34;user&#34;&gt;User&lt;/h2&gt;&#xA;&lt;p&gt;The user@ mailing list is the preferred mailing list for end-user&#xA;questions and discussion.&lt;/p&gt;</description>
+      <description>User The user@ mailing list is the preferred mailing list for end-user questions and discussion.
+Please use the specific module&amp;rsquo;s -dev@ mailing list to address developers on a specific technical question. The Hadoop user mailing list is : user@hadoop.apache.org.
+Subscribe to List Unsubscribe from List Archives 中文用户可利用user-zh邮件列表以中文发问
+订阅邮件列表 取消订阅 归档邮件 In order to post to the list, it is necessary to first subscribe to it.
+Security The security mailing list is a private list for discussion of potential security vulnerabilities issues.</description>
     </item>
+    
     <item>
       <title>Hadoop Version Control System</title>
       <link>https://hadoop.apache.org/version_control.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/version_control.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;h2 id=&#34;overview&#34;&gt;Overview&lt;/h2&gt;&#xA;&lt;p&gt;The Hadoop source code resides in the Apache git repository, and available from here:&#xA;&lt;a href=&#34;https://gitbox.apache.org/repos/asf?p=hadoop.git&#34;&gt;https://gitbox.apache.org/repos/asf?p=hadoop.git&lt;/a&gt;&lt;/p&gt;</description>
+      <description>Overview The Hadoop source code resides in the Apache git repository, and available from here: https://gitbox.apache.org/repos/asf?p=hadoop.git
+The changes are also mirrored to the github repository https://github.com/apache/hadoop
+Hdfs, Yarn, Mapreduce and other components all are parts of this one repository.</description>
     </item>
+    
     <item>
       <title>Modules</title>
       <link>https://hadoop.apache.org/modules.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/modules.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;The project includes these modules:&lt;/p&gt;</description>
+      <description> The project includes these modules:
+Hadoop Common: The common utilities that support the other Hadoop modules. Hadoop Distributed File System (HDFS™): A distributed file system that provides high-throughput access to application data. Hadoop YARN: A framework for job scheduling and cluster resource management. Hadoop MapReduce: A YARN-based system for parallel processing of large data sets. </description>
     </item>
+    
     <item>
       <title>Privacy</title>
       <link>https://hadoop.apache.org/privacy_policy.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/privacy_policy.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Information about your use of this website is collected using server&#xA;access logs and a tracking cookie. The collected information consists of&#xA;the following:&lt;/p&gt;</description>
+      <description>Information about your use of this website is collected using server access logs and a tracking cookie. The collected information consists of the following:
+The IP address from which you access the website; The type of browser and operating system you use to access our site; The date and time you access our site; The pages you visit; and The addresses of pages from where you followed a link to our site.</description>
     </item>
+    
     <item>
       <title>Related projects</title>
       <link>https://hadoop.apache.org/related.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/related.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Other Hadoop-related projects at Apache include:&lt;/p&gt;</description>
+      <description>Other Hadoop-related projects at Apache include:
+Ambari™: A web-based tool for provisioning, managing, and monitoring Apache Hadoop clusters which includes support for Hadoop HDFS, Hadoop MapReduce, Hive, HCatalog, HBase, ZooKeeper, Oozie, Pig and Sqoop. Ambari also provides a dashboard for viewing cluster health such as heatmaps and ability to view MapReduce, Pig and Hive applications visually alongwith features to diagnose their performance characteristics in a user-friendly manner. Avro™: A data serialization system.</description>
     </item>
+    
     <item>
       <title>Who We are</title>
       <link>https://hadoop.apache.org/who.html</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/who.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;h2 id=&#34;apache-hadoop-project-members&#34;&gt;Apache Hadoop Project Members&lt;/h2&gt;&#xA;&lt;p&gt;We ask that you please do not send us emails privately asking for&#xA;support. We are non-paid volunteers who help out with the project and we&#xA;do not necessarily have the time or energy to help people on an&#xA;individual basis. Instead, we have setup mailing lists for each module&#xA;which often contain hundreds of individuals who will help answer&#xA;detailed requests for help. The benefit of using mailing lists over&#xA;private communication is that it is a shared resource where others can&#xA;also learn from common mistakes and as a community we all grow together.&lt;/p&gt;</description>
+      <description>Apache Hadoop Project Members We ask that you please do not send us emails privately asking for support. We are non-paid volunteers who help out with the project and we do not necessarily have the time or energy to help people on an individual basis. Instead, we have setup mailing lists for each module which often contain hundreds of individuals who will help answer detailed requests for help. The benefit of using mailing lists over private communication is that it is a shared resource where others can also learn from common mistakes and as a community we all grow together.</description>
     </item>
+    
   </channel>
 </rss>

--- a/content/issue_tracking.html
+++ b/content/issue_tracking.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -163,7 +166,7 @@
 you do the following:</p>
 <ul>
 <li>Search the Apache JIRA database.</li>
-<li>Check the users <a href="/mailing_lists.html#Users">mailing lists</a>, both by searching the archives and by asking questions.</li>
+<li>Check the users <a href="mailing_lists.html#Users">mailing lists</a>, both by searching the archives and by asking questions.</li>
 </ul>
 <p>Jira subprojects:</p>
 <ul>
@@ -181,7 +184,7 @@ you do the following:</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -192,12 +195,24 @@ you do the following:</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/mailing_lists.html
+++ b/content/mailing_lists.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -185,7 +188,7 @@ security. Please use the user mailing list for such issues.
 The Hadoop security mailing list is : <a href="mailto:security@hadoop.apache.org">security@hadoop.apache.org</a>.</p>
 <p>In order to post to the list, it is <strong>NOT</strong> necessary to first subscribe
 to it.</p>
-<p>For information on published vulnerabilities please see our <a href="/cve_list.html">CVE list</a>.</p>
+<p>For information on published vulnerabilities please see our <a href="cve_list.html">CVE list</a>.</p>
 <p>This mailing list is only for discussing security vulnerabilities in hadoop &lsquo;source&rsquo; code, <strong>NOT</strong> security advisories for thirdparty libraries. For security issues related to thirdparty libraries use the dev/user mailing lists.
 However, when after analysis it turns out the advisory impacts Hadoop, that should be discussed on the security list.</p>
 <p>The thirdparty library versions in the upcoming releases can be checked here:</p>
@@ -220,7 +223,7 @@ List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/hadoop-common-dev/">Archives</a></li>
 </ul>
 <h3 id="commits">Commits</h3>
-<p>If you&rsquo;d like to see changes made in the Hadoop Common <a href="/version_control.html">version control
+<p>If you&rsquo;d like to see changes made in the Hadoop Common <a href="version_control.html">version control
 system</a>, please subscribe to the Hadoop Common
 commits mailing list.</p>
 <p>The Hadoop Common commits mailing list is:
@@ -233,7 +236,7 @@ List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/hadoop-common-commits/">Archives</a></li>
 </ul>
 <h3 id="issues">Issues</h3>
-<p>If you&rsquo;d like to see changes made in the Hadoop Common <a href="/issue_tracking.html">issue tracking
+<p>If you&rsquo;d like to see changes made in the Hadoop Common <a href="issue_tracking.html">issue tracking
 system</a>, please subscribe to the Hadoop Common
 issues mailing list.</p>
 <p>The Hadoop Common issues mailing list is:
@@ -257,7 +260,7 @@ List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/hadoop-hdfs-dev/">Archives</a></li>
 </ul>
 <h3 id="commits-1">Commits</h3>
-<p>If you&rsquo;d like to see changes made in the HDFS <a href="/version_control.html">version control
+<p>If you&rsquo;d like to see changes made in the HDFS <a href="version_control.html">version control
 system</a>, please subscribe to the HDFS commits
 mailing list.</p>
 <p>The HDFS commits mailing list is: <a href="mailto:hdfs-commits@hadoop.apache.org">hdfs-commits@hadoop.apache.org</a>.</p>
@@ -268,7 +271,7 @@ List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/hadoop-hdfs-commits/">Archives</a></li>
 </ul>
 <h3 id="issues-1">Issues</h3>
-<p>If you&rsquo;d like to see changes made in the Hadoop HDFS <a href="/issue_tracking.html">issue tracking
+<p>If you&rsquo;d like to see changes made in the Hadoop HDFS <a href="issue_tracking.html">issue tracking
 system</a>, please subscribe to the Hadoop Hdfs issues
 mailing list.</p>
 <p>The Hadoop HDFS issues mailing list is: <a href="mailto:hdfs-issues@hadoop.apache.org">hdfs-issues@hadoop.apache.org</a>.</p>
@@ -290,7 +293,7 @@ List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/hadoop-yarn-dev/">Archives</a></li>
 </ul>
 <h3 id="commits-2">Commits</h3>
-<p>If you&rsquo;d like to see changes made in the YARN <a href="/version_control.html">version control
+<p>If you&rsquo;d like to see changes made in the YARN <a href="version_control.html">version control
 system</a>, please subscribe to the YARN commits
 mailing list.</p>
 <p>The YARN commits mailing list is: <a href="mailto:yarn-commits@hadoop.apache.org">yarn-commits@hadoop.apache.org</a>.</p>
@@ -301,7 +304,7 @@ List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/hadoop-yarn-commits/">Archives</a></li>
 </ul>
 <h3 id="issues-2">Issues</h3>
-<p>If you&rsquo;d like to see changes made in the Hadoop YARN <a href="/issue_tracking.html">issue tracking
+<p>If you&rsquo;d like to see changes made in the Hadoop YARN <a href="issue_tracking.html">issue tracking
 system</a>, please subscribe to the Hadoop Yarn issues
 mailing list.</p>
 <p>The Hadoop YARN issues mailing list is: <a href="mailto:yarn-issues@hadoop.apache.org">yarn-issues@hadoop.apache.org</a>.</p>
@@ -325,7 +328,7 @@ List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/hadoop-mapreduce-dev/">Archives</a></li>
 </ul>
 <h3 id="commits-3">Commits</h3>
-<p>If you&rsquo;d like to see changes made in the Hadoop MapReduce <a href="/version_control.html">version
+<p>If you&rsquo;d like to see changes made in the Hadoop MapReduce <a href="version_control.html">version
 control system</a>, please subscribe to the Hadoop
 MapReduce commits mailing list.</p>
 <p>The Hadoop MapReduce commits mailing list is:
@@ -338,7 +341,7 @@ List</a></li>
 <li><a href="http://mail-archives.apache.org/mod_mbox/hadoop-mapreduce-commits/">Archives</a></li>
 </ul>
 <h3 id="issues-3">Issues</h3>
-<p>If you&rsquo;d like to see changes made in the Hadoop MapReduce <a href="/issue_tracking.html">issue
+<p>If you&rsquo;d like to see changes made in the Hadoop MapReduce <a href="issue_tracking.html">issue
 tracking system</a>, please subscribe to the Hadoop
 MapReduce issues mailing list.</p>
 <p>The Hadoop MapReduce issues mailing list is:
@@ -359,7 +362,7 @@ List</a></li>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -370,12 +373,24 @@ List</a></li>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/modules.html
+++ b/content/modules.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -174,7 +177,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -185,12 +188,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news.html
+++ b/content/news.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -399,7 +402,7 @@ project.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -410,12 +413,24 @@ project.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2008-07-xx-terabyte-sort.html
+++ b/content/news/2008-07-xx-terabyte-sort.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -174,7 +177,7 @@ won.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -185,12 +188,24 @@ won.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2008-11-xx-apachecon.html
+++ b/content/news/2008-11-xx-apachecon.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -168,7 +171,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -179,12 +182,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2009-03-xx-apachecon-eu.html
+++ b/content/news/2009-03-xx-apachecon-eu.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -169,7 +172,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -180,12 +183,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2009-07-xx-subprojects.html
+++ b/content/news/2009-07-xx-subprojects.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -176,7 +179,7 @@ individual sites for more detailed information.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -187,12 +190,24 @@ individual sites for more detailed information.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2010-05-xx-avro-hbase.html
+++ b/content/news/2010-05-xx-avro-hbase.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -171,7 +174,7 @@ Apache projects.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -182,12 +185,24 @@ Apache projects.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2010-10-xx-hive-pig.html
+++ b/content/news/2010-10-xx-hive-pig.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -171,7 +174,7 @@ Apache projects.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -182,12 +185,24 @@ Apache projects.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2011-01-xx-zookeeper.html
+++ b/content/news/2011-01-xx-zookeeper.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -170,7 +173,7 @@ project.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -181,12 +184,24 @@ project.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2011-03-xx-award.html
+++ b/content/news/2011-03-xx-award.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -172,7 +175,7 @@ site</a></p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -183,12 +186,24 @@ site</a></p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2018-10-01-ozone-0.2.1-alpha.html
+++ b/content/news/2018-10-01-ozone-0.2.1-alpha.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -170,7 +173,7 @@ using Hadoop Distributed Data Store.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -181,12 +184,24 @@ using Hadoop Distributed Data Store.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2018-11-22-ozone-0.3.0-alpha.html
+++ b/content/news/2018-11-22-ozone-0.3.0-alpha.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -169,7 +172,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -180,12 +183,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2019-05-07-ozone-0.4.0-alpha.html
+++ b/content/news/2019-05-07-ozone-0.4.0-alpha.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -171,7 +174,7 @@ and Yarn.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -182,12 +185,24 @@ and Yarn.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2019-10-13-ozone-0.4.1-alpha.html
+++ b/content/news/2019-10-13-ozone-0.4.1-alpha.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -169,7 +172,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -180,12 +183,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2020-03-24-ozone-0.5.0-beta.html
+++ b/content/news/2020-03-24-ozone-0.5.0-beta.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -169,7 +172,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -180,12 +183,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2020-09-02-ozone-1.0.0.html
+++ b/content/news/2020-09-02-ozone-1.0.0.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -169,7 +172,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -180,12 +183,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2021-04-17-ozone-1.1.0.html
+++ b/content/news/2021-04-17-ozone-1.1.0.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -169,7 +172,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -180,12 +183,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/2021-12-17-log4shell.html
+++ b/content/news/2021-12-17-log4shell.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -169,7 +172,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -180,12 +183,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/news/index.xml
+++ b/content/news/index.xml
@@ -4,122 +4,168 @@
     <title>News on Apache Hadoop</title>
     <link>https://hadoop.apache.org/news.html</link>
     <description>Recent content in News on Apache Hadoop</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <copyright>Copyright © 2006-{year} The Apache Software Foundation</copyright>
-    <lastBuildDate>Fri, 17 Dec 2021 00:00:00 +0000</lastBuildDate>
-    <atom:link href="https://hadoop.apache.org/news/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Fri, 17 Dec 2021 00:00:00 +0000</lastBuildDate><atom:link href="https://hadoop.apache.org/news/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Hadoop is not susceptible to log4shell vulnerability</title>
       <link>https://hadoop.apache.org/news/2021-12-17-log4shell.html</link>
       <pubDate>Fri, 17 Dec 2021 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2021-12-17-log4shell.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop, as of today depends on log4j 1.x, which is &lt;em&gt;NOT&lt;/em&gt; susceptible to the attack (CVE-2021-44228).&lt;/p&gt;</description>
+      <description>Hadoop, as of today depends on log4j 1.x, which is NOT susceptible to the attack (CVE-2021-44228).
+For more information check the published CVEs page.</description>
     </item>
+    
     <item>
       <title>Ozone 1.1.0 is released</title>
       <link>https://hadoop.apache.org/news/2021-04-17-ozone-1.1.0.html</link>
       <pubDate>Sat, 17 Apr 2021 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2021-04-17-ozone-1.1.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;General available(GA) release of Apache Hadoop Ozone with Volume/Bucket Quota Support, Security related enhancements, ofs/o3fs performance improvements, Recon improvements etc.&lt;/p&gt;</description>
+      <description>General available(GA) release of Apache Hadoop Ozone with Volume/Bucket Quota Support, Security related enhancements, ofs/o3fs performance improvements, Recon improvements etc.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Ozone 1.0.0 is released</title>
       <link>https://hadoop.apache.org/news/2020-09-02-ozone-1.0.0.html</link>
       <pubDate>Wed, 02 Sep 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2020-09-02-ozone-1.0.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;First general available(GA) release of Apache Hadoop Ozone with OM HA, OFS, Security phase II, Ozone Filesystem performance improvement, security enabled Hadoop 2.x support, bucket link, Recon / Recon UI improvment, etc.&lt;/p&gt;</description>
+      <description>First general available(GA) release of Apache Hadoop Ozone with OM HA, OFS, Security phase II, Ozone Filesystem performance improvement, security enabled Hadoop 2.x support, bucket link, Recon / Recon UI improvment, etc.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Ozone 0.5.0-beta is released</title>
       <link>https://hadoop.apache.org/news/2020-03-24-ozone-0.5.0-beta.html</link>
       <pubDate>Tue, 24 Mar 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2020-03-24-ozone-0.5.0-beta.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;First beta release of Apache Hadoop Ozone with GDPR Right to Erasure, Network Topology Awareness, O3FS, and improved scalability/stability.&lt;/p&gt;</description>
+      <description>First beta release of Apache Hadoop Ozone with GDPR Right to Erasure, Network Topology Awareness, O3FS, and improved scalability/stability.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Ozone 0.4.1-alpha is released</title>
       <link>https://hadoop.apache.org/news/2019-10-13-ozone-0.4.1-alpha.html</link>
       <pubDate>Sun, 13 Oct 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2019-10-13-ozone-0.4.1-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Next version of Apache Hadoop Ozone is released with  Native ACLs, K8s support and improved stability.&lt;/p&gt;</description>
+      <description>Next version of Apache Hadoop Ozone is released with Native ACLs, K8s support and improved stability.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Ozone 0.4.0-alpha is released</title>
       <link>https://hadoop.apache.org/news/2019-05-07-ozone-0.4.0-alpha.html</link>
       <pubDate>Tue, 07 May 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2019-05-07-ozone-0.4.0-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Ozone 0.4.0 alpha version supports kerberos and transparent data encryption.&#xA;This is first secure Ozone release. It is compatible with apache Spark, Hive&#xA;and Yarn.&lt;/p&gt;</description>
+      <description>Ozone 0.4.0 alpha version supports kerberos and transparent data encryption. This is first secure Ozone release. It is compatible with apache Spark, Hive and Yarn.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Ozone 0.3.0-alpha is released</title>
       <link>https://hadoop.apache.org/news/2018-11-22-ozone-0.3.0-alpha.html</link>
       <pubDate>Thu, 22 Nov 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2018-11-22-ozone-0.3.0-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Next version of Apache Hadoop Ozone is released with S3 support and improved stability.&lt;/p&gt;</description>
+      <description>Next version of Apache Hadoop Ozone is released with S3 support and improved stability.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Ozone release 0.2.1-alpha available</title>
       <link>https://hadoop.apache.org/news/2018-10-01-ozone-0.2.1-alpha.html</link>
       <pubDate>Mon, 01 Oct 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2018-10-01-ozone-0.2.1-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first version of Apache Hadoop Ozone. Ozone is an Object store for Hadoop built&#xA;using Hadoop Distributed Data Store.&lt;/p&gt;</description>
+      <description>This is the first version of Apache Hadoop Ozone. Ozone is an Object store for Hadoop built using Hadoop Distributed Data Store.
+For more information check the ozone site.</description>
     </item>
+    
     <item>
       <title>Apache Hadoop takes top prize at Media Guardian Innovation Awards</title>
       <link>https://hadoop.apache.org/news/2011-03-xx-award.html</link>
       <pubDate>Thu, 31 Mar 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2011-03-xx-award.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Described by the judging panel as a &amp;ldquo;Swiss army knife of the 21st&#xA;century&amp;rdquo;, Apache Hadoop picked up the &lt;em&gt;innovator of the year&lt;/em&gt; award for&#xA;having the potential to change the face of media innovations.&lt;/p&gt;</description>
+      <description>Described by the judging panel as a &amp;ldquo;Swiss army knife of the 21st century&amp;rdquo;, Apache Hadoop picked up the innovator of the year award for having the potential to change the face of media innovations.
+See The Guardian web site</description>
     </item>
+    
     <item>
       <title>ZooKeeper Graduates</title>
       <link>https://hadoop.apache.org/news/2011-01-xx-zookeeper.html</link>
       <pubDate>Sun, 30 Jan 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2011-01-xx-zookeeper.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop&amp;rsquo;s ZooKeeper subproject has graduated to become a top-level Apache&#xA;project.&lt;/p&gt;</description>
+      <description>Hadoop&amp;rsquo;s ZooKeeper subproject has graduated to become a top-level Apache project.
+Apache ZooKeeper can now be found at http://zookeeper.apache.org/</description>
     </item>
+    
     <item>
       <title>Hive and Pig Graduate</title>
       <link>https://hadoop.apache.org/news/2010-10-xx-hive-pig.html</link>
       <pubDate>Sat, 30 Oct 2010 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2010-10-xx-hive-pig.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop&amp;rsquo;s Hive and Pig subprojects have graduated to become top-level&#xA;Apache projects.&lt;/p&gt;</description>
+      <description>Hadoop&amp;rsquo;s Hive and Pig subprojects have graduated to become top-level Apache projects.
+Apache Hive can now be found at http://hive.apache.org/
+Pig can now be found at http://pig.apache.org/</description>
     </item>
+    
     <item>
       <title>Avro and HBase Graduate</title>
       <link>https://hadoop.apache.org/news/2010-05-xx-avro-hbase.html</link>
       <pubDate>Mon, 31 May 2010 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2010-05-xx-avro-hbase.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop&amp;rsquo;s Avro and HBase subprojects have graduated to become top-level&#xA;Apache projects.&lt;/p&gt;</description>
+      <description>Hadoop&amp;rsquo;s Avro and HBase subprojects have graduated to become top-level Apache projects.
+Apache Avro can now be found at http://avro.apache.org/
+Apache HBase can now be found at http://hbase.apache.org/</description>
     </item>
+    
     <item>
       <title>New Hadoop Subprojects</title>
       <link>https://hadoop.apache.org/news/2009-07-xx-subprojects.html</link>
       <pubDate>Fri, 31 Jul 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2009-07-xx-subprojects.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Hadoop is getting bigger!&lt;/p&gt;</description>
+      <description>Hadoop is getting bigger!
+Hadoop Core is renamed Hadoop Common. MapReduce and the Hadoop Distributed File System (HDFS) are now separate subprojects. Avro and Chukwa are new Hadoop subprojects. See the summary descriptions for all subprojects above. Visit the individual sites for more detailed information.</description>
     </item>
+    
     <item>
       <title>ApacheCon EU</title>
       <link>https://hadoop.apache.org/news/2009-03-xx-apachecon-eu.html</link>
       <pubDate>Tue, 31 Mar 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2009-03-xx-apachecon-eu.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;In case you missed it&amp;hellip;. &lt;a href=&#34;http://www.eu.apachecon.com/c/aceu2009/&#34;&gt;ApacheCon Europe&#xA;2009&lt;/a&gt;&lt;/p&gt;</description>
+      <description>In case you missed it&amp;hellip;. ApacheCon Europe 2009</description>
     </item>
+    
     <item>
       <title>ApacheCon US 2008</title>
       <link>https://hadoop.apache.org/news/2008-11-xx-apachecon.html</link>
       <pubDate>Sun, 30 Nov 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2008-11-xx-apachecon.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;In case you missed it&amp;hellip;. &lt;a href=&#34;http://us.apachecon.com/c/acus2008/&#34;&gt;ApacheCon US 2008&lt;/a&gt;&lt;/p&gt;</description>
+      <description>In case you missed it&amp;hellip;. ApacheCon US 2008</description>
     </item>
+    
     <item>
       <title>July 2008 - Hadoop Wins Terabyte Sort Benchmark</title>
       <link>https://hadoop.apache.org/news/2008-07-xx-terabyte-sort.html</link>
       <pubDate>Thu, 31 Jul 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/news/2008-07-xx-terabyte-sort.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;&lt;a href=&#34;http://developer.yahoo.com/blogs/hadoop/2008/07/apache_hadoop_wins_terabyte_sort_benchmark.html&#34;&gt;Hadoop Wins Terabyte Sort&#xA;Benchmark&lt;/a&gt;:&#xA;One of Yahoo&amp;rsquo;s Hadoop clusters sorted 1 terabyte of data in 209 seconds,&#xA;which beat the previous record of 297 seconds in the annual general&#xA;purpose (Daytona) &lt;a href=&#34;http://sortbenchmark.org/&#34;&gt;terabyte sort benchmark&lt;/a&gt;.&#xA;This is the first time that either a Java or an open source program has&#xA;won.&lt;/p&gt;</description>
+      <description>Hadoop Wins Terabyte Sort Benchmark: One of Yahoo&amp;rsquo;s Hadoop clusters sorted 1 terabyte of data in 209 seconds, which beat the previous record of 297 seconds in the annual general purpose (Daytona) terabyte sort benchmark. This is the first time that either a Java or an open source program has won.</description>
     </item>
+    
   </channel>
 </rss>

--- a/content/news/page/2.html
+++ b/content/news/page/2.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -323,7 +326,7 @@ won.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -334,12 +337,24 @@ won.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/privacy_policy.html
+++ b/content/privacy_policy.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -190,7 +193,7 @@ manner and for the purpose described above.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -201,12 +204,24 @@ manner and for the purpose described above.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/related.html
+++ b/content/related.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -209,7 +212,7 @@ service for distributed applications.</li>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -220,12 +223,24 @@ service for distributed applications.</li>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release.html
+++ b/content/release.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -481,7 +484,7 @@ detail the changes since 3.3.1.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -492,12 +495,24 @@ detail the changes since 3.3.1.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.14.1.html
+++ b/content/release/0.14.1.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -217,7 +220,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -228,12 +231,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.14.3.html
+++ b/content/release/0.14.3.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -201,7 +204,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -212,12 +215,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.14.4.html
+++ b/content/release/0.14.4.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -201,7 +204,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -212,12 +215,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.15.0.html
+++ b/content/release/0.15.0.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -209,7 +212,7 @@ Upgrade</a> page for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -220,12 +223,24 @@ Upgrade</a> page for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.15.1.html
+++ b/content/release/0.15.1.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -201,7 +204,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -212,12 +215,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.15.2.html
+++ b/content/release/0.15.2.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -201,7 +204,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -212,12 +215,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.15.3.html
+++ b/content/release/0.15.3.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -201,7 +204,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -212,12 +215,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.16.0.html
+++ b/content/release/0.16.0.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -207,7 +210,7 @@ Upgrade</a> page for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -218,12 +221,24 @@ Upgrade</a> page for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.16.1.html
+++ b/content/release/0.16.1.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -202,7 +205,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -213,12 +216,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.16.2.html
+++ b/content/release/0.16.2.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -203,7 +206,7 @@ maintained at <a href="https://hadoop.apache.org/hbase/">https://hadoop.apache.o
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -214,12 +217,24 @@ maintained at <a href="https://hadoop.apache.org/hbase/">https://hadoop.apache.o
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.16.3.html
+++ b/content/release/0.16.3.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -201,7 +204,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -212,12 +215,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.16.4.html
+++ b/content/release/0.16.4.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -201,7 +204,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -212,12 +215,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.17.0.html
+++ b/content/release/0.17.0.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -203,7 +206,7 @@ optimizations.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -214,12 +217,24 @@ optimizations.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.17.1.html
+++ b/content/release/0.17.1.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -203,7 +206,7 @@ optimizations.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -214,12 +217,24 @@ optimizations.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.17.2.html
+++ b/content/release/0.17.2.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -202,7 +205,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -213,12 +216,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.18.0.html
+++ b/content/release/0.18.0.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.18.1.html
+++ b/content/release/0.18.1.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -207,7 +210,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -218,12 +221,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.18.2.html
+++ b/content/release/0.18.2.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -207,7 +210,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -218,12 +221,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.18.3.html
+++ b/content/release/0.18.3.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -207,7 +210,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -218,12 +221,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.19.0.html
+++ b/content/release/0.19.0.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.19.1.html
+++ b/content/release/0.19.1.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -211,7 +214,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -222,12 +225,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.19.2.html
+++ b/content/release/0.19.2.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -207,7 +210,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -218,12 +221,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.20.0.html
+++ b/content/release/0.20.0.html
@@ -21,7 +21,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -127,10 +127,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -141,13 +151,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -210,7 +213,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -221,12 +224,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.20.1.html
+++ b/content/release/0.20.1.html
@@ -21,7 +21,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -127,10 +127,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -141,13 +151,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -209,7 +212,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -220,12 +223,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.20.2.html
+++ b/content/release/0.20.2.html
@@ -21,7 +21,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -127,10 +127,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -141,13 +151,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -209,7 +212,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -220,12 +223,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.20.203.0.html
+++ b/content/release/0.20.203.0.html
@@ -23,7 +23,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -129,10 +129,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -143,13 +153,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -213,7 +216,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -224,12 +227,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.20.204.0.html
+++ b/content/release/0.20.204.0.html
@@ -23,7 +23,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -129,10 +129,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -143,13 +153,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -218,7 +221,7 @@ this release</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -229,12 +232,24 @@ this release</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.20.205.0.html
+++ b/content/release/0.20.205.0.html
@@ -23,7 +23,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -129,10 +129,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -143,13 +153,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -218,7 +221,7 @@ calls currently fail in secure mode.</li>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -229,12 +232,24 @@ calls currently fail in secure mode.</li>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.21.0.html
+++ b/content/release/0.21.0.html
@@ -19,7 +19,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -125,10 +125,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -139,13 +149,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -211,7 +214,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -222,12 +225,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.22.0.html
+++ b/content/release/0.22.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -231,7 +234,7 @@ ChainMapper/Reducer.</li>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -242,12 +245,24 @@ ChainMapper/Reducer.</li>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.0.html
+++ b/content/release/0.23.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -216,7 +219,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -227,12 +230,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.1.html
+++ b/content/release/0.23.1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -218,7 +221,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -229,12 +232,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.10.html
+++ b/content/release/0.23.10.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.11.html
+++ b/content/release/0.23.11.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.3.html
+++ b/content/release/0.23.3.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.4.html
+++ b/content/release/0.23.4.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -209,7 +212,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -220,12 +223,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.5.html
+++ b/content/release/0.23.5.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.6.html
+++ b/content/release/0.23.6.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.7.html
+++ b/content/release/0.23.7.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.8.html
+++ b/content/release/0.23.8.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/0.23.9.html
+++ b/content/release/0.23.9.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.0.0.html
+++ b/content/release/1.0.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.0.1.html
+++ b/content/release/1.0.1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.0.2.html
+++ b/content/release/1.0.2.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.0.3.html
+++ b/content/release/1.0.3.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -213,7 +216,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -224,12 +227,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.0.4.html
+++ b/content/release/1.0.4.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -216,7 +219,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -227,12 +230,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.1.0.html
+++ b/content/release/1.1.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -221,7 +224,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -232,12 +235,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.1.1.html
+++ b/content/release/1.1.1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -206,7 +209,7 @@ Notes</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -217,12 +220,24 @@ Notes</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.1.2.html
+++ b/content/release/1.1.2.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -206,7 +209,7 @@ Notes</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -217,12 +220,24 @@ Notes</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.2.0.html
+++ b/content/release/1.2.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -219,7 +222,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -230,12 +233,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/1.2.1.html
+++ b/content/release/1.2.1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -207,7 +210,7 @@ list of 18 bug fixes and patches since the previous release 1.2.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -218,12 +221,24 @@ list of 18 bug fixes and patches since the previous release 1.2.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.0.0-alpha.html
+++ b/content/release/2.0.0-alpha.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -217,7 +220,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -228,12 +231,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.0.1-alpha.html
+++ b/content/release/2.0.1-alpha.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -207,7 +210,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -218,12 +221,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.0.2-alpha.html
+++ b/content/release/2.0.2-alpha.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -210,7 +213,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -221,12 +224,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.0.3-alpha.html
+++ b/content/release/2.0.3-alpha.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -221,7 +224,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -232,12 +235,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.0.4-alpha.html
+++ b/content/release/2.0.4-alpha.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.0.5-alpha.html
+++ b/content/release/2.0.5-alpha.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.0.6-alpha.html
+++ b/content/release/2.0.6-alpha.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.1.0-beta.html
+++ b/content/release/2.1.0-beta.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -219,7 +222,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -230,12 +233,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.1.1-beta.html
+++ b/content/release/2.1.1-beta.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.10.0.html
+++ b/content/release/2.10.0.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -210,7 +213,7 @@ detail the changes since 2.9.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -221,12 +224,24 @@ detail the changes since 2.9.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.10.1.html
+++ b/content/release/2.10.1.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -210,7 +213,7 @@ detail the changes since 2.10.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -221,12 +224,24 @@ detail the changes since 2.10.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.10.2.html
+++ b/content/release/2.10.2.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -210,7 +213,7 @@ please check <a href="http://hadoop.apache.org/docs/r2.10.2/hadoop-project-dist/
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -221,12 +224,24 @@ please check <a href="http://hadoop.apache.org/docs/r2.10.2/hadoop-project-dist/
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.2.0.html
+++ b/content/release/2.2.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -232,7 +235,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -243,12 +246,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.3.0.html
+++ b/content/release/2.3.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.4.0.html
+++ b/content/release/2.4.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -219,7 +222,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -230,12 +233,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.4.1.html
+++ b/content/release/2.4.1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -213,7 +216,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -224,12 +227,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.5.0.html
+++ b/content/release/2.5.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -222,7 +225,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -233,12 +236,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.5.1.html
+++ b/content/release/2.5.1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -205,7 +208,7 @@ fixes a few release issues with 2.5.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -216,12 +219,24 @@ fixes a few release issues with 2.5.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.5.2.html
+++ b/content/release/2.5.2.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -205,7 +208,7 @@ fixes a few critical issues in 2.5.1</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -216,12 +219,24 @@ fixes a few critical issues in 2.5.1</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.6.0.html
+++ b/content/release/2.6.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -253,7 +256,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -264,12 +267,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.6.1.html
+++ b/content/release/2.6.1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.6.2.html
+++ b/content/release/2.6.2.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.6.3.html
+++ b/content/release/2.6.3.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.6.4.html
+++ b/content/release/2.6.4.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for the list of 46 bug fixes and patches since the previous release
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for the list of 46 bug fixes and patches since the previous release
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.6.5.html
+++ b/content/release/2.6.5.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for the list of 79 critical bug fixes and since the previous release
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for the list of 79 critical bug fixes and since the previous release
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.7.0.html
+++ b/content/release/2.7.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -238,7 +241,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -249,12 +252,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.7.1.html
+++ b/content/release/2.7.1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -209,7 +212,7 @@ stable release of 2.7.x.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -220,12 +223,24 @@ stable release of 2.7.x.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.7.2.html
+++ b/content/release/2.7.2.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for the list of 155 bug fixes and patches since the previous release
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for the list of 155 bug fixes and patches since the previous release
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.7.3.html
+++ b/content/release/2.7.3.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -207,7 +210,7 @@ for the list of 221 bug fixes and patches since the previous release
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -218,12 +221,24 @@ for the list of 221 bug fixes and patches since the previous release
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.7.4.html
+++ b/content/release/2.7.4.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -205,7 +208,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -216,12 +219,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.7.5.html
+++ b/content/release/2.7.5.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ release 2.7.4.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ release 2.7.4.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.7.6.html
+++ b/content/release/2.7.6.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -209,7 +212,7 @@ groups mapping service.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -220,12 +223,24 @@ groups mapping service.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.7.7.html
+++ b/content/release/2.7.7.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -204,7 +207,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -215,12 +218,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.8.0.html
+++ b/content/release/2.8.0.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.8.1.html
+++ b/content/release/2.8.1.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -213,7 +216,7 @@ release in the 2.8.x line.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -224,12 +227,24 @@ release in the 2.8.x line.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.8.2.html
+++ b/content/release/2.8.2.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ and
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ and
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.8.3.html
+++ b/content/release/2.8.3.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -216,7 +219,7 @@ and
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -227,12 +230,24 @@ and
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.8.4.html
+++ b/content/release/2.8.4.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -216,7 +219,7 @@ and
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -227,12 +230,24 @@ and
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.8.5.html
+++ b/content/release/2.8.5.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -216,7 +219,7 @@ and
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -227,12 +230,24 @@ and
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.9.0.html
+++ b/content/release/2.9.0.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -218,7 +221,7 @@ will contain fixes from further stabilization and downstream adoption.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -229,12 +232,24 @@ will contain fixes from further stabilization and downstream adoption.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.9.1.html
+++ b/content/release/2.9.1.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ and
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ and
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/2.9.2.html
+++ b/content/release/2.9.2.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -210,7 +213,7 @@ detail the changes since 2.9.1.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -221,12 +224,24 @@ detail the changes since 2.9.1.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.0.0-alpha1.html
+++ b/content/release/3.0.0-alpha1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ detail all the changes since the previous minor release 2.7.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ detail all the changes since the previous minor release 2.7.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.0.0-alpha2.html
+++ b/content/release/3.0.0-alpha2.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ and <a href="https://hadoop.apache.org/docs/r3.0.0-alpha2/hadoop-project-dist/ha
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ and <a href="https://hadoop.apache.org/docs/r3.0.0-alpha2/hadoop-project-dist/ha
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.0.0-alpha4.html
+++ b/content/release/3.0.0-alpha4.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -214,7 +217,7 @@ and <a href="https://hadoop.apache.org/docs/r3.0.0-alpha4/hadoop-project-dist/ha
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -225,12 +228,24 @@ and <a href="https://hadoop.apache.org/docs/r3.0.0-alpha4/hadoop-project-dist/ha
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.0.0-beta1.html
+++ b/content/release/3.0.0-beta1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ and <a href="https://hadoop.apache.org/docs/r3.0.0-beta1/hadoop-project-dist/had
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ and <a href="https://hadoop.apache.org/docs/r3.0.0-beta1/hadoop-project-dist/had
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.0.0.html
+++ b/content/release/3.0.0.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -214,7 +217,7 @@ detail the changes since 3.0.0-beta1.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -225,12 +228,24 @@ detail the changes since 3.0.0-beta1.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.0.1.html
+++ b/content/release/3.0.1.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -220,7 +223,7 @@ detail the changes since 3.0.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -231,12 +234,24 @@ detail the changes since 3.0.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.0.2.html
+++ b/content/release/3.0.2.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -208,7 +211,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -219,12 +222,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.0.3.html
+++ b/content/release/3.0.3.html
@@ -22,7 +22,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -128,10 +128,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -142,13 +152,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -213,7 +216,7 @@ detail the changes since 3.0.2.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -224,12 +227,24 @@ detail the changes since 3.0.2.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.1.0.html
+++ b/content/release/3.1.0.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ detail the changes since 3.0.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ detail the changes since 3.0.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.1.1.html
+++ b/content/release/3.1.1.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -211,7 +214,7 @@ detail the changes since 3.1.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -222,12 +225,24 @@ detail the changes since 3.1.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.1.2.html
+++ b/content/release/3.1.2.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -209,7 +212,7 @@ please check <a href="https://hadoop.apache.org/docs/r3.1.2/hadoop-project-dist/
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -220,12 +223,24 @@ please check <a href="https://hadoop.apache.org/docs/r3.1.2/hadoop-project-dist/
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.1.3.html
+++ b/content/release/3.1.3.html
@@ -26,7 +26,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -132,10 +132,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -146,13 +156,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -211,7 +214,7 @@ please check <a href="https://hadoop.apache.org/docs/r3.1.3/hadoop-project-dist/
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -222,12 +225,24 @@ please check <a href="https://hadoop.apache.org/docs/r3.1.3/hadoop-project-dist/
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.1.4.html
+++ b/content/release/3.1.4.html
@@ -26,7 +26,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -132,10 +132,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -146,13 +156,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -211,7 +214,7 @@ please check <a href="http://hadoop.apache.org/docs/r3.1.4/hadoop-project-dist/h
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -222,12 +225,24 @@ please check <a href="http://hadoop.apache.org/docs/r3.1.4/hadoop-project-dist/h
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.2.0.html
+++ b/content/release/3.2.0.html
@@ -24,7 +24,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -130,10 +130,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -144,13 +154,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -210,7 +213,7 @@ detail the changes since 3.1.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -221,12 +224,24 @@ detail the changes since 3.1.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.2.1.html
+++ b/content/release/3.2.1.html
@@ -26,7 +26,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -132,10 +132,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -146,13 +156,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -212,7 +215,7 @@ detail the changes since 3.2.0</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -223,12 +226,24 @@ detail the changes since 3.2.0</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.2.2.html
+++ b/content/release/3.2.2.html
@@ -26,7 +26,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -132,10 +132,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -146,13 +156,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -212,7 +215,7 @@ detail the changes since 3.2.1.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -223,12 +226,24 @@ detail the changes since 3.2.1.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.2.3.html
+++ b/content/release/3.2.3.html
@@ -26,7 +26,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -132,10 +132,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -146,13 +156,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -212,7 +215,7 @@ detail the changes since 3.2.2.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -223,12 +226,24 @@ detail the changes since 3.2.2.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.2.4.html
+++ b/content/release/3.2.4.html
@@ -26,7 +26,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -132,10 +132,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -146,13 +156,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -212,7 +215,7 @@ please check <a href="http://hadoop.apache.org/docs/r3.2.4/hadoop-project-dist/h
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -223,12 +226,24 @@ please check <a href="http://hadoop.apache.org/docs/r3.2.4/hadoop-project-dist/h
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.3.0.html
+++ b/content/release/3.3.0.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ For details of please check <a href="http://hadoop.apache.org/docs/r3.3.0/hadoop
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ For details of please check <a href="http://hadoop.apache.org/docs/r3.3.0/hadoop
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.3.1.html
+++ b/content/release/3.3.1.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -217,7 +220,7 @@ detail the changes since 3.3.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -228,12 +231,24 @@ detail the changes since 3.3.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.3.2.html
+++ b/content/release/3.3.2.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -217,7 +220,7 @@ detail the changes since 3.3.1.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -228,12 +231,24 @@ detail the changes since 3.3.1.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.3.3.html
+++ b/content/release/3.3.3.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -218,7 +221,7 @@ please check <a href="http://hadoop.apache.org/docs/r3.3.3/hadoop-project-dist/h
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -229,12 +232,24 @@ please check <a href="http://hadoop.apache.org/docs/r3.3.3/hadoop-project-dist/h
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.3.4.html
+++ b/content/release/3.3.4.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -222,7 +225,7 @@ please check <a href="http://hadoop.apache.org/docs/r3.3.4/hadoop-project-dist/h
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -233,12 +236,24 @@ please check <a href="http://hadoop.apache.org/docs/r3.3.4/hadoop-project-dist/h
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.3.5.html
+++ b/content/release/3.3.5.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -241,7 +244,7 @@ to this release or disable prefetching by setting
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -252,12 +255,24 @@ to this release or disable prefetching by setting
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.3.6.html
+++ b/content/release/3.3.6.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -233,7 +236,7 @@ please check <a href="http://hadoop.apache.org/docs/r3.3.6/hadoop-project-dist/h
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -244,12 +247,24 @@ please check <a href="http://hadoop.apache.org/docs/r3.3.6/hadoop-project-dist/h
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.4.0.html
+++ b/content/release/3.4.0.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -215,7 +218,7 @@ For details of please check <a href="http://hadoop.apache.org/docs/r3.4.0/hadoop
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -226,12 +229,24 @@ For details of please check <a href="http://hadoop.apache.org/docs/r3.4.0/hadoop
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/3.4.1.html
+++ b/content/release/3.4.1.html
@@ -25,7 +25,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -131,10 +131,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -145,13 +155,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -230,7 +233,7 @@ and <a href="http://hadoop.apache.org/docs/r3.4.1/hadoop-project-dist/hadoop-com
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -241,12 +244,24 @@ and <a href="http://hadoop.apache.org/docs/r3.4.1/hadoop-project-dist/hadoop-com
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/index.xml
+++ b/content/release/index.xml
@@ -4,850 +4,1242 @@
     <title>Releases on Apache Hadoop</title>
     <link>https://hadoop.apache.org/release.html</link>
     <description>Recent content in Releases on Apache Hadoop</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <copyright>Copyright © 2006-{year} The Apache Software Foundation</copyright>
-    <lastBuildDate>Fri, 18 Oct 2024 00:00:00 +0000</lastBuildDate>
-    <atom:link href="https://hadoop.apache.org/release/index.xml" rel="self" type="application/rss+xml" />
+    <lastBuildDate>Fri, 18 Oct 2024 00:00:00 +0000</lastBuildDate><atom:link href="https://hadoop.apache.org/release/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Release 3.4.1 available</title>
       <link>https://hadoop.apache.org/release/3.4.1.html</link>
       <pubDate>Fri, 18 Oct 2024 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.4.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a release of Apache Hadoop 3.4.1 line.&lt;/p&gt;</description>
+      <description>This is a release of Apache Hadoop 3.4.1 line.
+Users of Apache Hadoop 3.4.0 and earlier should upgrade to this release.
+All users are encouraged to read the overview of major changes since release 3.4.0.
+We have also introduced a lean tar which is a small tar file that does not contain the AWS SDK because the size of AWS SDK is itself 500 MB. This can ease usage for non AWS users.</description>
     </item>
+    
     <item>
       <title>Release 3.4.0 available</title>
       <link>https://hadoop.apache.org/release/3.4.0.html</link>
       <pubDate>Sun, 17 Mar 2024 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.4.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first release of Apache Hadoop 3.4 line. It contains 2888 bug fixes, improvements and enhancements since 3.3.&lt;/p&gt;</description>
+      <description>This is the first release of Apache Hadoop 3.4 line. It contains 2888 bug fixes, improvements and enhancements since 3.3.
+Users are encouraged to read the overview of major changes. For details of please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.3.6 available</title>
       <link>https://hadoop.apache.org/release/3.3.6.html</link>
       <pubDate>Fri, 23 Jun 2023 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.6.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a release of Apache Hadoop 3.3 line.&lt;/p&gt;</description>
+      <description>This is a release of Apache Hadoop 3.3 line.
+It contains 117 bug fixes, improvements and enhancements since 3.3.5. Users of Apache Hadoop 3.3.5 and earlier should upgrade to this release.
+Feature highlights:
+SBOM artifacts Starting from this release, Hadoop publishes Software Bill of Materials (SBOM) using CycloneDX Maven plugin. For more information on SBOM, please go to SBOM.
+HDFS RBF: RDBMS based token storage support HDFS Router-Router Based Federation now supports storing delegation tokens on MySQL, HADOOP-18535 which improves token operation through over the original Zookeeper-based implementation.</description>
     </item>
+    
     <item>
       <title>Release 3.3.5 available</title>
       <link>https://hadoop.apache.org/release/3.3.5.html</link>
       <pubDate>Wed, 22 Mar 2023 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a release of Apache Hadoop 3.3 line.&lt;/p&gt;</description>
+      <description>This is a release of Apache Hadoop 3.3 line.
+Key changes include
+A big update of dependencies to try and keep those reports of transitive CVEs under control -both genuine and false positives. Critical fix to ABFS input stream prefetching for correct reading. Vectored IO API for all FSDataInputStream implementations, with high-performance versions for file:// and s3a:// filesystems. file:// through java native IO s3a:// parallel GET requests. Arm64 binaries. Note, because the arm64 release was on a different platform, the jar files may not match those of the x86 release -and therefore the maven artifacts.</description>
     </item>
+    
     <item>
       <title>Release 3.3.4 available</title>
       <link>https://hadoop.apache.org/release/3.3.4.html</link>
       <pubDate>Mon, 08 Aug 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a release of Apache Hadoop 3.3 line.&lt;/p&gt;</description>
+      <description>This is a release of Apache Hadoop 3.3 line.
+It contains a small number security and critical integration fixes since 3.3.3.
+Users of Apache Hadoop 3.3.3 should upgrade to this release.
+Users of hadoop 2.x and hadoop 3.2 should also upgrade to the 3.3.x line. As well as feature enhancements, this is the sole branch currently receiving fixes for anything other than critical security/data integrity issues.
+Users are encouraged to read the overview of major changes since release 3.</description>
     </item>
+    
     <item>
       <title>Release 3.2.4 available</title>
       <link>https://hadoop.apache.org/release/3.2.4.html</link>
       <pubDate>Fri, 22 Jul 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the third stable release of Apache Hadoop 3.2 line.&lt;/p&gt;</description>
+      <description>This is the third stable release of Apache Hadoop 3.2 line.
+It contains 153 bug fixes, improvements and enhancements since 3.2.3.
+Users are encouraged to read the overview of major changes since 3.2.3. For details of 153 bug fixes, improvements, and other enhancements since the previous 3.2.3 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 2.10.2 available</title>
       <link>https://hadoop.apache.org/release/2.10.2.html</link>
       <pubDate>Tue, 31 May 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.10.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 2.10 line.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 2.10 line.
+It contains 211 bug fixes, improvements and enhancements since 2.10.1.
+Users are encouraged to read the overview of major changes since 2.10.1. For details of 211 bug fixes, improvements, and other enhancements since the previous 2.10.1 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.3.3 available</title>
       <link>https://hadoop.apache.org/release/3.3.3.html</link>
       <pubDate>Tue, 17 May 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the third stable release of the Apache Hadoop 3.3 line.&lt;/p&gt;</description>
+      <description>This is the third stable release of the Apache Hadoop 3.3 line.
+It contains 23 bug fixes, improvements and enhancements since 3.3.2.
+This is primarily a security update; for this reason, upgrading is strongly advised.
+Users are encouraged to read the overview of major changes since 3.3.2. For details of bug fixes, improvements, and other enhancements since the previous 3.3.2 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.2.3 available</title>
       <link>https://hadoop.apache.org/release/3.2.3.html</link>
       <pubDate>Mon, 28 Mar 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the third stable release of Apache Hadoop 3.2 line. It contains 328 bug fixes, improvements and enhancements since 3.2.2.&lt;/p&gt;</description>
+      <description>This is the third stable release of Apache Hadoop 3.2 line. It contains 328 bug fixes, improvements and enhancements since 3.2.2.
+Users are encouraged to read the overview of major changes since 3.2.2. For details of 328 bug fixes, improvements, and other enhancements since the previous 3.2.2 release, please check release notes and changelog detail the changes since 3.2.2.</description>
     </item>
+    
     <item>
       <title>Release 3.3.2 available</title>
       <link>https://hadoop.apache.org/release/3.3.2.html</link>
       <pubDate>Thu, 03 Mar 2022 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.3 line. It contains 284 bug fixes, improvements and enhancements since 3.3.1.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.3 line. It contains 284 bug fixes, improvements and enhancements since 3.3.1.
+Users are encouraged to read the overview of major changes since 3.3.1. For details of 284 bug fixes, improvements, and other enhancements since the previous 3.3.1 release, please check release notes and changelog detail the changes since 3.3.1.</description>
     </item>
+    
     <item>
       <title>Release 3.3.1 available</title>
       <link>https://hadoop.apache.org/release/3.3.1.html</link>
       <pubDate>Tue, 15 Jun 2021 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first stable release of Apache Hadoop 3.3.x line. It contains 697 bug fixes, improvements and enhancements since 3.3.0.&lt;/p&gt;</description>
+      <description>This is the first stable release of Apache Hadoop 3.3.x line. It contains 697 bug fixes, improvements and enhancements since 3.3.0.
+Users are encouraged to read the overview of major changes since 3.3.0. For details of 697 bug fixes, improvements, and other enhancements since the previous 3.3.0 release, please check release notes and changelog detail the changes since 3.3.0.</description>
     </item>
+    
     <item>
       <title>Release 3.2.2 available</title>
       <link>https://hadoop.apache.org/release/3.2.2.html</link>
       <pubDate>Sat, 09 Jan 2021 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.2 line. It contains 516 bug fixes, improvements and enhancements since 3.2.1.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.2 line. It contains 516 bug fixes, improvements and enhancements since 3.2.1.
+Users are encouraged to read the overview of major changes since 3.2.1. For details of 516 bug fixes, improvements, and other enhancements since the previous 3.2.1 release, please check release notes and changelog detail the changes since 3.2.1.</description>
     </item>
+    
     <item>
       <title>Release 2.10.1 available</title>
       <link>https://hadoop.apache.org/release/2.10.1.html</link>
       <pubDate>Mon, 21 Sep 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.10.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 2.10 line. It contains 218 bug fixes, improvements and enhancements since 2.10.0.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 2.10 line. It contains 218 bug fixes, improvements and enhancements since 2.10.0.
+Users are encouraged to read the overview of major changes since 2.10.0. For details of 218 bug fixes, improvements, and other enhancements since the previous 2.10.0 release, please check release notes and changelog detail the changes since 2.10.0.</description>
     </item>
+    
     <item>
       <title>Release 3.1.4 available</title>
       <link>https://hadoop.apache.org/release/3.1.4.html</link>
       <pubDate>Mon, 03 Aug 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.1 line. It contains 308 bug fixes, improvements and enhancements since 3.1.3.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.1 line. It contains 308 bug fixes, improvements and enhancements since 3.1.3.
+Users are encouraged to read the overview of major changes since 3.1.3. For details of 308 bug fixes, improvements, and other enhancements since the previous 3.1.3 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.3.0 available</title>
       <link>https://hadoop.apache.org/release/3.3.0.html</link>
       <pubDate>Tue, 14 Jul 2020 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.3.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first release of Apache Hadoop 3.3 line. It contains 2148 bug fixes, improvements and enhancements since 3.2.&lt;/p&gt;</description>
+      <description>This is the first release of Apache Hadoop 3.3 line. It contains 2148 bug fixes, improvements and enhancements since 3.2.
+Users are encouraged to read the overview of major changes. For details of please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 2.10.0 available</title>
       <link>https://hadoop.apache.org/release/2.10.0.html</link>
       <pubDate>Tue, 29 Oct 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.10.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first stable release of Apache Hadoop 2.10 line. It contains 362 bug fixes, improvements and enhancements since 2.9.0.&lt;/p&gt;</description>
+      <description>This is the first stable release of Apache Hadoop 2.10 line. It contains 362 bug fixes, improvements and enhancements since 2.9.0.
+Users are encouraged to read the overview of major changes since 2.9.0. For details of 362 bug fixes, improvements, and other enhancements since the previous 2.9.0 release, please check release notes and changelog detail the changes since 2.9.0.</description>
     </item>
+    
     <item>
       <title>Release 3.1.3 available</title>
       <link>https://hadoop.apache.org/release/3.1.3.html</link>
       <pubDate>Mon, 21 Oct 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the third stable release of Apache Hadoop 3.1 line. It contains 246 bug fixes, improvements and enhancements since 3.1.2.&lt;/p&gt;</description>
+      <description>This is the third stable release of Apache Hadoop 3.1 line. It contains 246 bug fixes, improvements and enhancements since 3.1.2.
+Users are encouraged to read the overview of major changes since 3.1.2. For details of the bug fixes, improvements, and other enhancements since the previous 3.1.2 release, please check release notes and changelog</description>
     </item>
+    
     <item>
       <title>Release 3.2.1 available</title>
       <link>https://hadoop.apache.org/release/3.2.1.html</link>
       <pubDate>Sun, 22 Sep 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.2 line. It contains 493 bug fixes, improvements and enhancements since 3.2.0&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.2 line. It contains 493 bug fixes, improvements and enhancements since 3.2.0
+Users are encouraged to read the overview of major changes since 3.2.0 For details of 493 bug fixes, improvements, and other enhancements since the previous 3.2.0 release, please check release notes and changelog detail the changes since 3.2.0</description>
     </item>
+    
     <item>
       <title>Release 3.1.2 available</title>
       <link>https://hadoop.apache.org/release/3.1.2.html</link>
       <pubDate>Wed, 06 Feb 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second stable release of Apache Hadoop 3.1 line. It contains 325 bug fixes, improvements and enhancements since 3.1.1.&lt;/p&gt;</description>
+      <description>This is the second stable release of Apache Hadoop 3.1 line. It contains 325 bug fixes, improvements and enhancements since 3.1.1.
+Users are encouraged to read the overview of major changes since 3.0.x. For details of 325 bug fixes, improvements, and other enhancements since the previous 3.1.1 release, please check release notes and changelog</description>
     </item>
+    
     <item>
       <title>Release 3.2.0 available</title>
       <link>https://hadoop.apache.org/release/3.2.0.html</link>
       <pubDate>Wed, 16 Jan 2019 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.2.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first stable release of Apache Hadoop 3.2 line. It contains 1092 bug fixes, improvements and enhancements since 3.1.0.&lt;/p&gt;</description>
+      <description>This is the first stable release of Apache Hadoop 3.2 line. It contains 1092 bug fixes, improvements and enhancements since 3.1.0.
+Users are encouraged to read the overview of major changes since 3.1.0. For details of 1092 bug fixes, improvements, and other enhancements since the previous 3.1.0 release, please check release notes and changelog detail the changes since 3.1.0.</description>
     </item>
+    
     <item>
       <title>Release 2.9.2 available</title>
       <link>https://hadoop.apache.org/release/2.9.2.html</link>
       <pubDate>Mon, 19 Nov 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.9.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.9 line. It contains 204 bug fixes, improvements and enhancements since 2.9.1.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.9 line. It contains 204 bug fixes, improvements and enhancements since 2.9.1.
+Users are encouraged to read the overview of major changes since 2.9.1. For details of 204 bug fixes, improvements, and other enhancements since the previous 2.9.1 release, please check release notes and changelog detail the changes since 2.9.1.</description>
     </item>
+    
     <item>
       <title>Release 2.8.5 available</title>
       <link>https://hadoop.apache.org/release/2.8.5.html</link>
       <pubDate>Sat, 15 Sep 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.8 line. It contains 33 bug&#xA;fixes, improvements and enhancements since 2.8.5.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.8 line. It contains 33 bug fixes, improvements and enhancements since 2.8.5.
+Users are encouraged to read the overview of major changes for major features and improvements for Apache Hadoop 2.8. For details of 33 fixes, improvements, and other enhancements since the 2.8.4 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.1.1 available</title>
       <link>https://hadoop.apache.org/release/3.1.1.html</link>
       <pubDate>Wed, 08 Aug 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first stable release of Apache Hadoop 3.1 line. It contains 435 bug fixes, improvements and enhancements since 3.1.0.&lt;/p&gt;</description>
+      <description>This is the first stable release of Apache Hadoop 3.1 line. It contains 435 bug fixes, improvements and enhancements since 3.1.0.
+Users are encouraged to read the overview of major changes since 3.1.0. For details of 435 bug fixes, improvements, and other enhancements since the previous 3.1.0 release, please check (https://hadoop.apache.org/docs/r3.1.1/hadoop-project-dist/hadoop-common/release/3.1.1/RELEASENOTES.3.1.1.html) and changelog detail the changes since 3.1.0.</description>
     </item>
+    
     <item>
       <title>Release 2.7.7 available</title>
       <link>https://hadoop.apache.org/release/2.7.7.html</link>
       <pubDate>Thu, 31 May 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.7.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a maintenance release of Apache Hadoop 2.7. It addresses CVE-2018-8009.&lt;/p&gt;</description>
+      <description>This is a maintenance release of Apache Hadoop 2.7. It addresses CVE-2018-8009.</description>
     </item>
+    
     <item>
       <title>Release 3.0.3 available</title>
       <link>https://hadoop.apache.org/release/3.0.3.html</link>
       <pubDate>Thu, 31 May 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 3.0 line. It contains 249 bug&#xA;fixes, improvments and other enhancements since 3.0.2.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 3.0 line. It contains 249 bug fixes, improvments and other enhancements since 3.0.2.
+Users are encouraged to read the overview of major changes since 3.0.2. For details of 249 bug fixes, improvements, and other enhancements since the previous 3.0.2 release, please check release notes andi changelog detail the changes since 3.0.2.</description>
     </item>
+    
     <item>
       <title>Release 2.8.4 available</title>
       <link>https://hadoop.apache.org/release/2.8.4.html</link>
       <pubDate>Tue, 15 May 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.8 line. It contains 77 bug&#xA;fixes, improvements and enhancements since 2.8.3.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.8 line. It contains 77 bug fixes, improvements and enhancements since 2.8.3.
+Users are encouraged to read the overview of major changes for major features and improvements for Apache Hadoop 2.8. For details of 77 fixes, improvements, and other enhancements since the 2.8.3 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 2.9.1 available</title>
       <link>https://hadoop.apache.org/release/2.9.1.html</link>
       <pubDate>Thu, 03 May 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.9.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.9 line. It contains 208 bug&#xA;fixes, improvements and enhancements since 2.9.0.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.9 line. It contains 208 bug fixes, improvements and enhancements since 2.9.0.
+Users are encouraged to read the overview of major changes for major features and improvements for Apache Hadoop 2.9. For details of 208 fixes, improvements, and other enhancements since the 2.9.0 release, please check release notes and changelog.</description>
     </item>
+    
     <item>
       <title>Release 3.0.2 available</title>
       <link>https://hadoop.apache.org/release/3.0.2.html</link>
       <pubDate>Sat, 21 Apr 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 3.0 line. This release fixes&#xA;the shard jars published in Hadoop 3.0.1.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 3.0 line. This release fixes the shard jars published in Hadoop 3.0.1.
+Please see the Hadoop 3.0.2 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.7.6 available</title>
       <link>https://hadoop.apache.org/release/2.7.6.html</link>
       <pubDate>Mon, 16 Apr 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.6.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.7 line.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.7 line.
+Please see the Hadoop 2.7.6 Release Notes for the full list of 46 bug fixes and optimizations since the previous release 2.7.5. It particularly enables POSIX groups support for LDAP groups mapping service.</description>
     </item>
+    
     <item>
       <title>Release 3.1.0 available</title>
       <link>https://hadoop.apache.org/release/3.1.0.html</link>
       <pubDate>Fri, 06 Apr 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.1.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first release of Apache Hadoop 3.1 line. It contains 768 bug&#xA;fixes, improvements and enhancements since 3.0.0&lt;/p&gt;</description>
+      <description>This is the first release of Apache Hadoop 3.1 line. It contains 768 bug fixes, improvements and enhancements since 3.0.0
+Users are encouraged to read the overview of major changes since 3.0.0. For details of 768 bug fixes, improvements, and other enhancements since the previous 3.0.0 release, please check release notes and changelog detail the changes since 3.0.0.</description>
     </item>
+    
     <item>
       <title>Release 3.0.1 available</title>
       <link>https://hadoop.apache.org/release/3.0.1.html</link>
       <pubDate>Sun, 25 Mar 2018 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;After four alpha releases and one beta release, 3.0.0 is generally&#xA;available. 3.0.0 consists of 302 bug fixes, improvements, and other&#xA;enhancements since 3.0.0-beta1. All together, 6242 issues were fixed as&#xA;part of the 3.0.0 release series since 2.7.0.&lt;/p&gt;</description>
+      <description>After four alpha releases and one beta release, 3.0.0 is generally available. 3.0.0 consists of 302 bug fixes, improvements, and other enhancements since 3.0.0-beta1. All together, 6242 issues were fixed as part of the 3.0.0 release series since 2.7.0.
+This is the next release of Apache Hadoop 3.0 line. It contains 49 bug fixes, improvements and enhancements since 3.0.0.
+Please note: 3.0.0 is deprecated after 3.0.1 because HDFS-12990 changes NameNode default RPC port back to 8020.</description>
     </item>
+    
     <item>
       <title>Release 2.9.0 available</title>
       <link>https://hadoop.apache.org/release/2.9.0.html</link>
       <pubDate>Sun, 17 Dec 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.9.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first GA release in the 2.9 release line. It includes 30 New&#xA;Features with 500+ subtasks, 407 Improvements, 790 Bug fixes new fixed&#xA;issues since 2.8.2. For major features and improvements for Apache&#xA;Hadoop 2.8.2 please refer: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.9.0/index.html&#34;&gt;overview of major&#xA;changes&lt;/a&gt;. For details&#xA;of 790 bug fixes, improvements, and other enhancements since the&#xA;previous 2.8.2 release, please check: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.9.0/hadoop-project-dist/hadoop-common/release/2.9.0/RELEASENOTES.2.9.0.html&#34;&gt;release&#xA;notes&lt;/a&gt;&#xA;and&#xA;&lt;a href=&#34;https://hadoop.apache.org/docs/r2.9.0/hadoop-project-dist/hadoop-common/release/2.9.0/CHANGES.2.9.0.html&#34;&gt;changelog&lt;/a&gt;&lt;/p&gt;</description>
+      <description>This is the first GA release in the 2.9 release line. It includes 30 New Features with 500+ subtasks, 407 Improvements, 790 Bug fixes new fixed issues since 2.8.2. For major features and improvements for Apache Hadoop 2.8.2 please refer: overview of major changes. For details of 790 bug fixes, improvements, and other enhancements since the previous 2.8.2 release, please check: release notes and changelog
+Please note: Although this release has been tested on fairly large clusters, production users can wait for a subsequent point release which will contain fixes from further stabilization and downstream adoption.</description>
     </item>
+    
     <item>
       <title>Release 2.7.5 available</title>
       <link>https://hadoop.apache.org/release/2.7.5.html</link>
       <pubDate>Thu, 14 Dec 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.7 line.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.7 line.
+Please see the Hadoop 2.7.5 Release Notes for the list of 34 bug fixes and optimizations since the previous release 2.7.4.</description>
     </item>
+    
     <item>
       <title>Release 3.0.0 generally available</title>
       <link>https://hadoop.apache.org/release/3.0.0.html</link>
       <pubDate>Wed, 13 Dec 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;After four alpha releases and one beta release, 3.0.0 is generally&#xA;available. 3.0.0 consists of 302 bug fixes, improvements, and other&#xA;enhancements since 3.0.0-beta1. All together, 6242 issues were fixed as&#xA;part of the 3.0.0 release series since 2.7.0.&lt;/p&gt;</description>
+      <description>After four alpha releases and one beta release, 3.0.0 is generally available. 3.0.0 consists of 302 bug fixes, improvements, and other enhancements since 3.0.0-beta1. All together, 6242 issues were fixed as part of the 3.0.0 release series since 2.7.0.
+Users are encouraged to read the overview of major changes in 3.0.0. The GA release notes and changelog detail the changes since 3.0.0-beta1.</description>
     </item>
+    
     <item>
       <title>Release 2.8.3 available</title>
       <link>https://hadoop.apache.org/release/2.8.3.html</link>
       <pubDate>Tue, 12 Dec 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.8 release line. It contains&#xA;79 bug fixes, improvments and other enhancements since 2.8.2.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.8 release line. It contains 79 bug fixes, improvments and other enhancements since 2.8.2.
+For major features and improvements for Apache Hadoop 2.8, please refer: overview of major changes. For details of 79 fixes, improvements, and other enhancements since the previous 2.8.2 release, please check: release notes and changelog</description>
     </item>
+    
     <item>
       <title>Release 2.8.2 available</title>
       <link>https://hadoop.apache.org/release/2.8.2.html</link>
       <pubDate>Tue, 24 Oct 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first GA release in the 2.8 release line. It contains 315&#xA;bug fixes, improvments and other enhancements since 2.8.1. For major&#xA;features and improvements for Apache Hadoop 2.8, please refer: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.2/index.html&#34;&gt;overview&#xA;of major changes&lt;/a&gt;. For&#xA;details of 315 fixes, improvements, and other enhancements since the&#xA;previous 2.8.1 release, please check: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.2/hadoop-project-dist/hadoop-common/release/2.8.2/RELEASENOTES.2.8.2.html&#34;&gt;release&#xA;notes&lt;/a&gt;&#xA;and&#xA;&lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.2/hadoop-project-dist/hadoop-common/release/2.8.2/CHANGES.2.8.2.html&#34;&gt;changelog&lt;/a&gt;&lt;/p&gt;</description>
+      <description>This is the first GA release in the 2.8 release line. It contains 315 bug fixes, improvments and other enhancements since 2.8.1. For major features and improvements for Apache Hadoop 2.8, please refer: overview of major changes. For details of 315 fixes, improvements, and other enhancements since the previous 2.8.1 release, please check: release notes and changelog</description>
     </item>
+    
     <item>
       <title>Release 3.0.0-beta1 available</title>
       <link>https://hadoop.apache.org/release/3.0.0-beta1.html</link>
       <pubDate>Tue, 03 Oct 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0-beta1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first beta release in the 3.0.0 release line. It consists of 576 bug fixes, improvements, and other enhancements since 3.0.0-alpha4. This is planned to be the final alpha release, with the next release being 3.0.0 GA.&lt;/p&gt;</description>
+      <description>This is the first beta release in the 3.0.0 release line. It consists of 576 bug fixes, improvements, and other enhancements since 3.0.0-alpha4. This is planned to be the final alpha release, with the next release being 3.0.0 GA.
+Please note that beta releases are API stable but come with no guarantees of quality, and are not intended for production use.
+Users are encouraged to read the overview of major changes coming in 3.</description>
     </item>
+    
     <item>
       <title>Release 2.7.4 available</title>
       <link>https://hadoop.apache.org/release/2.7.4.html</link>
       <pubDate>Fri, 04 Aug 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the next release of Apache Hadoop 2.7 line.&lt;/p&gt;</description>
+      <description>This is the next release of Apache Hadoop 2.7 line.
+Please see the Hadoop 2.7.4 Release Notes for the list of 264 bugs fixes and optimizations since the previous release 2.7.3.</description>
     </item>
+    
     <item>
       <title>Release 3.0.0-alpha4 available</title>
       <link>https://hadoop.apache.org/release/3.0.0-alpha4.html</link>
       <pubDate>Fri, 07 Jul 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0-alpha4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the fourth alpha release in the 3.0.0 release line. It consists&#xA;of 814 bug fixes, improvements, and other enhancements since&#xA;3.0.0-alpha3. This is planned to be the final alpha release, with the&#xA;next release being 3.0.0-beta1.&lt;/p&gt;</description>
+      <description>This is the fourth alpha release in the 3.0.0 release line. It consists of 814 bug fixes, improvements, and other enhancements since 3.0.0-alpha3. This is planned to be the final alpha release, with the next release being 3.0.0-beta1.
+Please note that alpha releases come with no guarantees of quality or API stability, and are not intended for production use.
+Users are encouraged to read the overview of major changes coming in 3.</description>
     </item>
+    
     <item>
       <title>Release 2.8.1 available</title>
       <link>https://hadoop.apache.org/release/2.8.1.html</link>
       <pubDate>Thu, 08 Jun 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a security release in the 2.8.0 release line. It consists of&#xA;2.8.0 plus security fixes. Users on 2.8.0 are encouraged to upgrade to&#xA;2.8.1.&lt;/p&gt;</description>
+      <description>This is a security release in the 2.8.0 release line. It consists of 2.8.0 plus security fixes. Users on 2.8.0 are encouraged to upgrade to 2.8.1.
+Please note that 2.8.x release line continues to be not yet ready for production use. Critical issues are being ironed out via testing and downstream adoption. Production users should wait for a subsequent release in the 2.8.x line.</description>
     </item>
+    
     <item>
       <title>Release 2.8.0 available</title>
       <link>https://hadoop.apache.org/release/2.8.0.html</link>
       <pubDate>Wed, 22 Mar 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.8.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.8.0 contains a number of significant features and enhancements. For major features and improvements, please refer: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.0/index.html&#34;&gt;overview of major changes&lt;/a&gt; coming in 2.8.0. For details of 2917 fixes, improvements, and new features since the previous 2.7.0 release, please check: &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-commonreleasenotes.html&#34;&gt;release notes&lt;/a&gt; and &lt;a href=&#34;https://hadoop.apache.org/docs/r2.8.0/hadoop-project-dist/hadoop-common/CHANGES.txt&#34;&gt;changelog&lt;/a&gt;&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.8.0 contains a number of significant features and enhancements. For major features and improvements, please refer: overview of major changes coming in 2.8.0. For details of 2917 fixes, improvements, and new features since the previous 2.7.0 release, please check: release notes and changelog
+Please note that this release is not yet ready for production use. Critical issues are being ironed out via testing and downstream adoption. Production users should wait for a 2.</description>
     </item>
+    
     <item>
       <title>Release 3.0.0-alpha2</title>
       <link>https://hadoop.apache.org/release/3.0.0-alpha2.html</link>
       <pubDate>Wed, 25 Jan 2017 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0-alpha2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second alpha in a series of planned alphas and betas leading up to a 3.0.0 GA release. The intention is to &amp;ldquo;release early, release often&amp;rdquo; to quickly iterate on feedback collected from downstream users.&lt;/p&gt;</description>
+      <description>This is the second alpha in a series of planned alphas and betas leading up to a 3.0.0 GA release. The intention is to &amp;ldquo;release early, release often&amp;rdquo; to quickly iterate on feedback collected from downstream users.
+Please note that alpha releases come with no guarantees of quality or API stability, and are not intended for production use.
+Users are encouraged to read the overview of major changes coming in 3.</description>
     </item>
+    
     <item>
       <title>Release 2.6.5 available</title>
       <link>https://hadoop.apache.org/release/2.6.5.html</link>
       <pubDate>Sat, 08 Oct 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 2.6 line.&lt;/p&gt;</description>
+      <description>A point release for the 2.6 line.
+Please see the Hadoop 2.6.5 Release Notes for the list of 79 critical bug fixes and since the previous release 2.6.4.</description>
     </item>
+    
     <item>
       <title>Release 3.0.0-alpha1 available</title>
       <link>https://hadoop.apache.org/release/3.0.0-alpha1.html</link>
       <pubDate>Sat, 03 Sep 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/3.0.0-alpha1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first alpha in a series of planned alphas and betas leading&#xA;up to a 3.0.0 GA release. The intention is to &amp;ldquo;release early, release&#xA;often&amp;rdquo; to quickly iterate on feedback collected from downstream users.&lt;/p&gt;</description>
+      <description>This is the first alpha in a series of planned alphas and betas leading up to a 3.0.0 GA release. The intention is to &amp;ldquo;release early, release often&amp;rdquo; to quickly iterate on feedback collected from downstream users.
+Please note that alpha releases come with no guarantees of quality or API stability, and are not intended for production use.
+Users are encouraged to read the overview of major changes coming in 3.</description>
     </item>
+    
     <item>
       <title>Release 2.7.3 available</title>
       <link>https://hadoop.apache.org/release/2.7.3.html</link>
       <pubDate>Fri, 26 Aug 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Please see the &lt;a href=&#34;https://hadoop.apache.org/docs/r2.7.3/hadoop-project-dist/hadoop-common/releasenotes.html&#34;&gt;Hadoop 2.7.3 Release&#xA;Notes&lt;/a&gt;&#xA;for the list of 221 bug fixes and patches since the previous release&#xA;2.7.2.&lt;/p&gt;</description>
+      <description>Please see the Hadoop 2.7.3 Release Notes for the list of 221 bug fixes and patches since the previous release 2.7.2.</description>
     </item>
+    
     <item>
       <title>Release 2.6.4 available</title>
       <link>https://hadoop.apache.org/release/2.6.4.html</link>
       <pubDate>Thu, 11 Feb 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 2.6 line.&lt;/p&gt;</description>
+      <description>A point release for the 2.6 line.
+Please see the Hadoop 2.6.4 Release Notes for the list of 46 bug fixes and patches since the previous release 2.6.3.</description>
     </item>
+    
     <item>
       <title>Release 2.7.2 (stable) available</title>
       <link>https://hadoop.apache.org/release/2.7.2.html</link>
       <pubDate>Mon, 25 Jan 2016 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 2.7 line.&lt;/p&gt;</description>
+      <description>A point release for the 2.7 line.
+Please see the Hadoop 2.7.2 Release Notes for the list of 155 bug fixes and patches since the previous release 2.7.1.</description>
     </item>
+    
     <item>
       <title>Release 2.6.3 available</title>
       <link>https://hadoop.apache.org/release/2.6.3.html</link>
       <pubDate>Thu, 17 Dec 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.6.3 is a point release in the 2.6.x release line, and&#xA;fixes a few critical issues in 2.6.2.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.6.3 is a point release in the 2.6.x release line, and fixes a few critical issues in 2.6.2.
+Please see the Hadoop 2.6.3 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.6.2 available</title>
       <link>https://hadoop.apache.org/release/2.6.2.html</link>
       <pubDate>Wed, 28 Oct 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.6.2 is a point release in the 2.6.x release line, and&#xA;fixes a few critical issues in 2.6.1.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.6.2 is a point release in the 2.6.x release line, and fixes a few critical issues in 2.6.1.
+Please see the Hadoop 2.6.2 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.6.1 available</title>
       <link>https://hadoop.apache.org/release/2.6.1.html</link>
       <pubDate>Wed, 23 Sep 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.6.1 is a point release in the 2.6.x release line, and&#xA;fixes a lot of critical issues in 2.6.0.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.6.1 is a point release in the 2.6.x release line, and fixes a lot of critical issues in 2.6.0.
+Please see the Hadoop 2.6.1 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.7.1 (stable) available</title>
       <link>https://hadoop.apache.org/release/2.7.1.html</link>
       <pubDate>Mon, 06 Jul 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 2.7 line. This release is now considered stable.&lt;/p&gt;</description>
+      <description>A point release for the 2.7 line. This release is now considered stable.
+Please see the Hadoop 2.7.1 Release Notes for the list of 131 bug fixes and patches since the previous release 2.7.0. Please look at the 2.7.0 section below for the list of enhancements enabled by this first stable release of 2.7.x.</description>
     </item>
+    
     <item>
       <title>Release 2.7.0 available</title>
       <link>https://hadoop.apache.org/release/2.7.0.html</link>
       <pubDate>Tue, 21 Apr 2015 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.7.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.7.0 contains a number of significant enhancements. A few&#xA;of them are noted below.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.7.0 contains a number of significant enhancements. A few of them are noted below.
+IMPORTANT notes This release drops support for JDK6 runtime and works with JDK 7+ only. This release is not yet ready for production use. Critical issues are being ironed out via testing and downstream adoption. Production users should wait for a 2.7.1/2.7.2 release. Hadoop Common HADOOP-9629 - Support Windows Azure Storage - Blob as a file system in Hadoop.</description>
     </item>
+    
     <item>
       <title>Release 2.5.2 available</title>
       <link>https://hadoop.apache.org/release/2.5.2.html</link>
       <pubDate>Wed, 19 Nov 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.5.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.5.2 is a point release in the 2.5.x release line, and&#xA;fixes a few critical issues in 2.5.1&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.5.2 is a point release in the 2.5.x release line, and fixes a few critical issues in 2.5.1</description>
     </item>
+    
     <item>
       <title>Release 2.6.0 available</title>
       <link>https://hadoop.apache.org/release/2.6.0.html</link>
       <pubDate>Tue, 18 Nov 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.6.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.6.0 contains a number of significant enhancements such&#xA;as:&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.6.0 contains a number of significant enhancements such as:
+Hadoop Common HADOOP-10433 - Key management server (beta) HADOOP-10607 - Credential provider (beta) Hadoop HDFS Heterogeneous Storage Tiers - Phase 2 HDFS-5682 - Application APIs for heterogeneous storage HDFS-7228 - SSD storage tier HDFS-5851 - Memory as a storage tier (beta) HDFS-6584 - Support for Archival Storage HDFS-6134 - Transparent data at rest encryption (beta) HDFS-2856 - Operating secure DataNode without requiring root access HDFS-6740 - Hot swap drive: support add/remove data node volumes without restarting data node (beta) HDFS-6606 - AES support for faster wire encryption Hadoop YARN YARN-896 - Support for long running services in YARN YARN-913 - Service Registry for applications YARN-666 - Support for rolling upgrades YARN-556 - Work-preserving restarts of ResourceManager YARN-1336 - Container-preserving restart of NodeManager YARN-796 - Support node labels during scheduling YARN-1051 - Support for time-based resource reservations in Capacity Scheduler (beta) YARN-1964 - Support running of applications natively in Docker containers (alpha) Please see the Hadoop 2.</description>
     </item>
+    
     <item>
       <title>Release 2.5.1 available</title>
       <link>https://hadoop.apache.org/release/2.5.1.html</link>
       <pubDate>Fri, 12 Sep 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.5.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.5.1 is a point release in the 2.5.x release line, and&#xA;fixes a few release issues with 2.5.0.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.5.1 is a point release in the 2.5.x release line, and fixes a few release issues with 2.5.0.</description>
     </item>
+    
     <item>
       <title>Release 2.5.0 available</title>
       <link>https://hadoop.apache.org/release/2.5.0.html</link>
       <pubDate>Mon, 11 Aug 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.5.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.5.0 is a minor release in the 2.x release line.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.5.0 is a minor release in the 2.x release line.
+The release includes the following major features and improvements:
+Authentication improvements when using an HTTP proxy server. A new Hadoop Metrics sink that allows writing directly to Graphite. Specification for Hadoop Compatible Filesystem effort. Support for POSIX-style filesystem extended attributes. OfflineImageViewer to browse an fsimage via the WebHDFS API. Supportability improvements and bug fixes to the NFS gateway.</description>
     </item>
+    
     <item>
       <title>Release 2.4.1 available</title>
       <link>https://hadoop.apache.org/release/2.4.1.html</link>
       <pubDate>Mon, 30 Jun 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.4.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.4.1 is a bug-fix release for the stable 2.4.x line.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.4.1 is a bug-fix release for the stable 2.4.x line.
+There is also a security bug fix in this minor release.
+CVE-2014-0229: Add privilege checks to HDFS admin sub-commands refreshNamenodes, deleteBlockPool and shutdownDatanode. Users are encouraged to immediately move to 2.4.1.
+Please see the Hadoop 2.4.1 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.11 available</title>
       <link>https://hadoop.apache.org/release/0.23.11.html</link>
       <pubDate>Fri, 27 Jun 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.11.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.11 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.4.0 available</title>
       <link>https://hadoop.apache.org/release/2.4.0.html</link>
       <pubDate>Mon, 07 Apr 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.4.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.4.0 contains a number of significant enhancements such&#xA;as:&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.4.0 contains a number of significant enhancements such as:
+Support for Access Control Lists in HDFS Native support for Rolling Upgrades in HDFS Usage of protocol-buffers for HDFS FSImage for smooth operational upgrades Complete HTTPS support in HDFS Support for Automatic Failover of the YARN ResourceManager Enhanced support for new applications on YARN with Application History Server and Application Timeline Server Support for strong SLAs in YARN CapacityScheduler via Preemption Please see the Hadoop 2.</description>
     </item>
+    
     <item>
       <title>Release 2.3.0 available</title>
       <link>https://hadoop.apache.org/release/2.3.0.html</link>
       <pubDate>Thu, 20 Feb 2014 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.3.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.3.0 contains a number of significant enhancements such&#xA;as:&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.3.0 contains a number of significant enhancements such as:
+Support for Heterogeneous Storage hierarchy in HDFS. In-memory cache for HDFS data with centralized administration and management. Simplified distribution of MapReduce binaries via HDFS in YARN Distributed Cache. Please see the Hadoop 2.3.0 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.10 available</title>
       <link>https://hadoop.apache.org/release/0.23.10.html</link>
       <pubDate>Wed, 11 Dec 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.10.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.10 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.2.0 available</title>
       <link>https://hadoop.apache.org/release/2.2.0.html</link>
       <pubDate>Tue, 15 Oct 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.2.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.2.0 is the &lt;strong&gt;GA&lt;/strong&gt; release of Apache Hadoop 2.x.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.2.0 is the GA release of Apache Hadoop 2.x.
+Users are encouraged to immediately move to 2.2.0 since this release is significantly more stable and is guaranteed to remain compatible in terms of both APIs and protocols.
+To recap, this release has a number of significant highlights compared to Hadoop 1.x:
+YARN - A general purpose resource management system for Hadoop to allow MapReduce and other other data processing frameworks and services High Availability for HDFS HDFS Federation HDFS Snapshots NFSv3 access to data in HDFS Support for running Hadoop on Microsoft Windows Binary Compatibility for MapReduce applications built on hadoop-1.</description>
     </item>
+    
     <item>
       <title>Release 2.1.1-beta available</title>
       <link>https://hadoop.apache.org/release/2.1.1-beta.html</link>
       <pubDate>Mon, 23 Sep 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.1.1-beta.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.1.1-beta is a bug-fix version of the beta release of&#xA;Apache Hadoop 2.x.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.1.1-beta is a bug-fix version of the beta release of Apache Hadoop 2.x.
+Please see the Hadoop 2.1.1-beta Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.1.0-beta available</title>
       <link>https://hadoop.apache.org/release/2.1.0-beta.html</link>
       <pubDate>Sun, 25 Aug 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.1.0-beta.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Apache Hadoop 2.1.0-beta is the &lt;strong&gt;beta&lt;/strong&gt; release of Apache Hadoop 2.x.&lt;/p&gt;</description>
+      <description>Apache Hadoop 2.1.0-beta is the beta release of Apache Hadoop 2.x.
+Users are encouraged to immediately move to 2.1.0-beta since this release is significantly more stable and has completley whetted set of APIs and wire-protocols for future compatibility.
+In addition, this release has a number of other significant highlights:
+HDFS Snapshots Support for running Hadoop on Microsoft Windows YARN API stabilization Binary Compatibility for MapReduce applications built on hadoop-1.x Substantial amount of integration testing with rest of projects in the ecosystem Please see the Hadoop 2.</description>
     </item>
+    
     <item>
       <title>Release 2.0.6-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.6-alpha.html</link>
       <pubDate>Fri, 23 Aug 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.6-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release delivers a number of critical bug-fixes for hadoop-2.x&#xA;uncovered during integration testing of previous release.&lt;/p&gt;</description>
+      <description>This release delivers a number of critical bug-fixes for hadoop-2.x uncovered during integration testing of previous release.
+Please see the Hadoop 2.0.6-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.2.1 (stable) available</title>
       <link>https://hadoop.apache.org/release/1.2.1.html</link>
       <pubDate>Thu, 01 Aug 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.2.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 1.2 line. This release is now considered stable.&lt;/p&gt;</description>
+      <description>A point release for the 1.2 line. This release is now considered stable.
+Please see the Hadoop 1.2.1 Release Notes for the list of 18 bug fixes and patches since the previous release 1.2.0.</description>
     </item>
+    
     <item>
       <title>Release 0.23.9 available</title>
       <link>https://hadoop.apache.org/release/0.23.9.html</link>
       <pubDate>Mon, 08 Jul 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.9.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.9 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.0.5-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.5-alpha.html</link>
       <pubDate>Thu, 06 Jun 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.5-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release delivers a number of critical bug-fixes for hadoop-2.x&#xA;uncovered during integration testing of previous release.&lt;/p&gt;</description>
+      <description>This release delivers a number of critical bug-fixes for hadoop-2.x uncovered during integration testing of previous release.
+Please see the Hadoop 2.0.5-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.8 available</title>
       <link>https://hadoop.apache.org/release/0.23.8.html</link>
       <pubDate>Wed, 05 Jun 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.8.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.8 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.2.0 available</title>
       <link>https://hadoop.apache.org/release/1.2.0.html</link>
       <pubDate>Mon, 13 May 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.2.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a beta release for version 1.2.&lt;/p&gt;</description>
+      <description>This is a beta release for version 1.2.
+This release delivers over 200 enhancements and bug-fixes, compared to the previous 1.1.2 release. Major enhancements include:
+DistCp v2 backported Web services for JobTracker WebHDFS enhancements Extensions of task placement and replica placement policy interfaces Offline Image Viewer backported Namenode more robust in case of edit log corruption Add NodeGroups level to NetworkTopology Add &amp;ldquo;unset&amp;rdquo; to Configuration API Please see the Hadoop 1.</description>
     </item>
+    
     <item>
       <title>Release 2.0.4-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.4-alpha.html</link>
       <pubDate>Thu, 25 Apr 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.4-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release delivers a number of critical bug-fixes for hadoop-2.x&#xA;uncovered during integration testing.&lt;/p&gt;</description>
+      <description>This release delivers a number of critical bug-fixes for hadoop-2.x uncovered during integration testing.
+Please see the Hadoop 2.0.4-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.7 available</title>
       <link>https://hadoop.apache.org/release/0.23.7.html</link>
       <pubDate>Thu, 18 Apr 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.7.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.7 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.1.2 available</title>
       <link>https://hadoop.apache.org/release/1.1.2.html</link>
       <pubDate>Fri, 15 Feb 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.1.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Point release for the 1.1.X line. Bug fixes and improvements, as&#xA;documented in the &lt;a href=&#34;https://hadoop.apache.org/docs/r1.1.2/releasenotes.html&#34;&gt;Hadoop 1.1.2 Release&#xA;Notes&lt;/a&gt;.&lt;/p&gt;</description>
+      <description>Point release for the 1.1.X line. Bug fixes and improvements, as documented in the Hadoop 1.1.2 Release Notes.</description>
     </item>
+    
     <item>
       <title>Release 2.0.3-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.3-alpha.html</link>
       <pubDate>Thu, 14 Feb 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.3-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the latest (alpha) version in the hadoop-2.x series.&lt;/p&gt;</description>
+      <description>This is the latest (alpha) version in the hadoop-2.x series.
+This release delivers significant major features and stability over previous releases in hadoop-2.x series:
+QJM for HDFS HA for NameNode Multi-resource scheduling (CPU and memory) for YARN YARN ResourceManager Restart Significant stability at scale for YARN (over 30,000 nodes and 14 million applications so far, at time of release) This release, like previous releases in hadoop-2.x series is still considered alpha primarily since some of APIs aren&amp;rsquo;t fully-baked and we expect some churn in future.</description>
     </item>
+    
     <item>
       <title>Release 0.23.6 available</title>
       <link>https://hadoop.apache.org/release/0.23.6.html</link>
       <pubDate>Thu, 07 Feb 2013 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.6.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.6 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.1.1 available</title>
       <link>https://hadoop.apache.org/release/1.1.1.html</link>
       <pubDate>Sat, 01 Dec 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.1.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;Point release for the 1.1.X line. Bug fixes and improvements, as&#xA;documented in the &lt;a href=&#34;https://hadoop.apache.org/docs/r1.1.1/releasenotes.html&#34;&gt;Hadoop 1.1.1 Release&#xA;Notes&lt;/a&gt;.&lt;/p&gt;</description>
+      <description>Point release for the 1.1.X line. Bug fixes and improvements, as documented in the Hadoop 1.1.1 Release Notes.</description>
     </item>
+    
     <item>
       <title>Release 0.23.5 available</title>
       <link>https://hadoop.apache.org/release/0.23.5.html</link>
       <pubDate>Wed, 28 Nov 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.5.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Bug fixes to continue&#xA;stabilization.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Bug fixes to continue stabilization.
+Please see the Hadoop 0.23.5 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.4 available</title>
       <link>https://hadoop.apache.org/release/0.23.4.html</link>
       <pubDate>Mon, 15 Oct 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;A point release for the 0.23.X line. Most notably this release now&#xA;incluses support for upgrading a 1.X HDFS cluster with append/synch&#xA;enabled.&lt;/p&gt;</description>
+      <description>A point release for the 0.23.X line. Most notably this release now incluses support for upgrading a 1.X HDFS cluster with append/synch enabled.
+Please see the Hadoop 0.23.4 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.1.0 available</title>
       <link>https://hadoop.apache.org/release/1.1.0.html</link>
       <pubDate>Sat, 13 Oct 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.1.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a beta release for version 1.1.&lt;/p&gt;</description>
+      <description>This is a beta release for version 1.1.
+This release has approximately 135 enhancements and bug fixes compared to Hadoop-1.0.4, including:
+Many performance improvements in HDFS, backported from trunk Improvements in Security to use SPNEGO instead of Kerberized SSL for HTTP transactions Lower default minimum heartbeat for task trackers from 3 sec to 300msec to increase job throughput on small clusters Port of Gridmix v3 Set MALLOC_ARENA_MAX in hadoop-config.sh to resolve problems with glibc in RHEL-6 Splittable bzip2 files Of course it also has the same security fix as release 1.</description>
     </item>
+    
     <item>
       <title>Release 1.0.4 available</title>
       <link>https://hadoop.apache.org/release/1.0.4.html</link>
       <pubDate>Fri, 12 Oct 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a Security Patch release for version 1.0.&lt;/p&gt;</description>
+      <description>This is a Security Patch release for version 1.0.
+There are four bug fixes and feature enhancements in this minor release:
+Security issue CVE-2012-4449: Hadoop tokens use a 20-bit secret HADOOP-7154 - set MALLOC_ARENA_MAX in hadoop-config.sh to resolve problems with glibc in RHEL-6 HDFS-3652 - FSEditLog failure removes the wrong edit stream when storage dirs have same name MAPREDUCE-4399 - Fix (up to 3x) performance regression in shuffle Please see the Hadoop 1.</description>
     </item>
+    
     <item>
       <title>Release 2.0.2-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.2-alpha.html</link>
       <pubDate>Tue, 09 Oct 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.2-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second (alpha) version in the hadoop-2.x series.&lt;/p&gt;</description>
+      <description>This is the second (alpha) version in the hadoop-2.x series.
+This delivers significant enhancements to HDFS HA. Also it has a significantly more stable version of YARN which, at the time of release, has already been deployed on a 2000 node cluster.
+Please see the Hadoop 2.0.2-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 0.23.3 available</title>
       <link>https://hadoop.apache.org/release/0.23.3.html</link>
       <pubDate>Mon, 17 Sep 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains YARN and MRv2 but does not have Name Node High&#xA;Avalability&lt;/p&gt;</description>
+      <description>This release contains YARN and MRv2 but does not have Name Node High Avalability
+Please see the Hadoop 0.23.3 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.0.1-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.1-alpha.html</link>
       <pubDate>Thu, 26 Jul 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.1-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains important security fixes over hadoop-2.0.0-alpha.&lt;/p&gt;</description>
+      <description>This release contains important security fixes over hadoop-2.0.0-alpha.
+Please see the Hadoop 2.0.1-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 2.0.0-alpha available</title>
       <link>https://hadoop.apache.org/release/2.0.0-alpha.html</link>
       <pubDate>Wed, 23 May 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/2.0.0-alpha.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the first (alpha) version in the hadoop-2.x series.&lt;/p&gt;</description>
+      <description>This is the first (alpha) version in the hadoop-2.x series.
+This delivers significant major features over the currently stable hadoop-1.x series including:
+HDFS HA for NameNode (manual failover) YARN aka NextGen MapReduce HDFS Federation Performance Wire-compatibility for both HDFS and YARN/MapReduce (using protobufs) Please see the Hadoop 2.0.0-alpha Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.0.3 available</title>
       <link>https://hadoop.apache.org/release/1.0.3.html</link>
       <pubDate>Wed, 16 May 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a bug fix release for version 1.0.&lt;/p&gt;</description>
+      <description>This is a bug fix release for version 1.0.
+Bug fixes and feature enhancements in this minor release include:
+4 patches in support of non-Oracle JDKs several patches to clean up error handling and log messages various production issue fixes Please see the Hadoop 1.0.3 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.0.2 available</title>
       <link>https://hadoop.apache.org/release/1.0.2.html</link>
       <pubDate>Tue, 03 Apr 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a bug fix release for version 1.0.&lt;/p&gt;</description>
+      <description>This is a bug fix release for version 1.0.
+Bug fixes and feature enhancements in this minor release include:
+Snappy compressor/decompressor is available Occassional deadlock in metrics serving thread fixed 64-bit secure datanodes failed to start, now fixed Changed package names for 64-bit rpm/debs to use &amp;ldquo;.x86_64.&amp;rdquo; instead of &amp;ldquo;.amd64.&amp;rdquo; Please see the Hadoop 1.0.2 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>Release 1.0.1 available</title>
       <link>https://hadoop.apache.org/release/1.0.1.html</link>
       <pubDate>Sat, 10 Mar 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is a bug fix release for version 1.0. This release is now&#xA;considered stable, replacing the long-standing 0.20.203.&lt;/p&gt;</description>
+      <description>This is a bug fix release for version 1.0. This release is now considered stable, replacing the long-standing 0.20.203.
+Bug fixes in this minor release include:
+Added hadoop-client and hadoop-minicluster artifacts for ease of client install and testing Support run-as-user in non-secure mode Better compatibility with Ganglia, HBase, and Sqoop Please see the Hadoop 1.0.1 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.23.1 available</title>
       <link>https://hadoop.apache.org/release/0.23.1.html</link>
       <pubDate>Mon, 27 Feb 2012 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the second alpha version of the hadoop-0.23 major release after&#xA;the first alpha 0.23.0. This release has significant improvements&#xA;compared to 0.23.0 but should still be considered as alpha-quality and&#xA;not for production use.&lt;/p&gt;</description>
+      <description>This is the second alpha version of the hadoop-0.23 major release after the first alpha 0.23.0. This release has significant improvements compared to 0.23.0 but should still be considered as alpha-quality and not for production use.
+hadoop-0.23.1 contains several major advances from 0.23.0:
+Lots of bug fixes and improvements in both HDFS and MapReduce Major performance work to make this release either match or exceed performance of Hadoop-1 in most aspects of both HDFS and MapReduce.</description>
     </item>
+    
     <item>
       <title>release 1.0.0 available</title>
       <link>https://hadoop.apache.org/release/1.0.0.html</link>
       <pubDate>Tue, 27 Dec 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/1.0.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;After six years of gestation, Hadoop reaches 1.0.0! This release is from&#xA;the 0.20-security code line, and includes support for:&lt;/p&gt;</description>
+      <description>After six years of gestation, Hadoop reaches 1.0.0! This release is from the 0.20-security code line, and includes support for:
+security HBase (append/hsynch/hflush, and security) webhdfs (with full support for security) performance enhanced access to local files for HBase other performance enhancements, bug fixes, and features Please see the complete Hadoop 1.0.0 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.22.0 available</title>
       <link>https://hadoop.apache.org/release/0.22.0.html</link>
       <pubDate>Sat, 10 Dec 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.22.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many bug fixes and optimizations compared to its&#xA;predecessor 0.21.0. See the &lt;a href=&#34;https://hadoop.apache.org/docs/r0.22.0/releasenotes.html&#34;&gt;Hadoop 0.22.0 Release&#xA;Notes&lt;/a&gt; for&#xA;details. Alternatively, you can look at the complete &lt;a href=&#34;https://hadoop.apache.org/docs/r0.22.0/changes.html&#34;&gt;change log for&#xA;this release&lt;/a&gt;&lt;/p&gt;</description>
+      <description>This release contains many bug fixes and optimizations compared to its predecessor 0.21.0. See the Hadoop 0.22.0 Release Notes for details. Alternatively, you can look at the complete change log for this release
+Notes:
+The following features are not supported in Hadoop 0.22.0.
+Security. Latest optimizations of the MapReduce framework introduced in the Hadoop 0.20.security line of releases. Disk-fail-in-place. JMX-based metrics v2. Hadoop 0.22.0 features
+HBase support with hflush and hsync.</description>
     </item>
+    
     <item>
       <title>release 0.23.0 available</title>
       <link>https://hadoop.apache.org/release/0.23.0.html</link>
       <pubDate>Fri, 11 Nov 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.23.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This is the alpha version of the hadoop-0.23 major release. This is the&#xA;first release we&amp;rsquo;ve made off Apache Hadoop trunk in a long while. This&#xA;release is alpha-quality and not yet ready for serious use.&lt;/p&gt;</description>
+      <description>This is the alpha version of the hadoop-0.23 major release. This is the first release we&amp;rsquo;ve made off Apache Hadoop trunk in a long while. This release is alpha-quality and not yet ready for serious use.
+hadoop-0.23 contains several major advances:
+HDFS Federation NextGen MapReduce (YARN) It also has several major performance improvements to both HDFS and MapReduce.
+See the Hadoop 0.23.0 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.20.205.0 available</title>
       <link>https://hadoop.apache.org/release/0.20.205.0.html</link>
       <pubDate>Mon, 17 Oct 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.205.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains improvements, new features, bug fixes and&#xA;optimizations. This release includes rpms and debs, all duly checksummed&#xA;and securely signed.&lt;/p&gt;</description>
+      <description>This release contains improvements, new features, bug fixes and optimizations. This release includes rpms and debs, all duly checksummed and securely signed.
+See the Hadoop 0.20.205.0 Release Notes for details. Alternatively, you can look at the complete change log for this release.
+Notes:
+This release includes a merge of append/hsynch/hflush capabilities from 0.20-append branch, to support HBase in secure mode. This release includes the new webhdfs file system, but webhdfs write calls currently fail in secure mode.</description>
     </item>
+    
     <item>
       <title>release 0.20.204.0 available</title>
       <link>https://hadoop.apache.org/release/0.20.204.0.html</link>
       <pubDate>Mon, 05 Sep 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.204.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains improvements, new features, bug fixes and&#xA;optimizations. This release includes rpms and debs for the first time.&lt;/p&gt;</description>
+      <description> This release contains improvements, new features, bug fixes and optimizations. This release includes rpms and debs for the first time.
+See the Hadoop 0.20.204.0 Release Notes for details. Alternatively, you can look at the complete change log for this release.
+Notes:
+The RPMs don&amp;rsquo;t work with security turned on. (HADOOP-7599) The NameNode&amp;rsquo;s edit log needs to be merged into the image via put the NameNode into safe mode run dfsadmin savenamespace command perform a normal upgrade </description>
     </item>
+    
     <item>
       <title>release 0.20.203.0 available</title>
       <link>https://hadoop.apache.org/release/0.20.203.0.html</link>
       <pubDate>Wed, 11 May 2011 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.203.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations. It is stable and has been deployed in large (4,500&#xA;machine) production clusters.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations. It is stable and has been deployed in large (4,500 machine) production clusters.
+See the Hadoop 0.20.203.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.21.0 available</title>
       <link>https://hadoop.apache.org/release/0.21.0.html</link>
       <pubDate>Mon, 23 Aug 2010 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.21.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations. It has not undergone testing at scale and should not be&#xA;considered stable or suitable for production. This release is being&#xA;classified as a minor release, which means that it should be API&#xA;compatible with 0.20.2.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations. It has not undergone testing at scale and should not be considered stable or suitable for production. This release is being classified as a minor release, which means that it should be API compatible with 0.20.2.
+See the Hadoop 0.21.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.20.2 available</title>
       <link>https://hadoop.apache.org/release/0.20.2.html</link>
       <pubDate>Fri, 26 Feb 2010 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.20.2 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.20.1 available</title>
       <link>https://hadoop.apache.org/release/0.20.1.html</link>
       <pubDate>Mon, 14 Sep 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.20.1 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.19.2 available</title>
       <link>https://hadoop.apache.org/release/0.19.2.html</link>
       <pubDate>Thu, 23 Jul 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.19.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.19.2 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.20.0 available</title>
       <link>https://hadoop.apache.org/release/0.20.0.html</link>
       <pubDate>Wed, 22 Apr 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.20.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.20.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.19.1 available</title>
       <link>https://hadoop.apache.org/release/0.19.1.html</link>
       <pubDate>Tue, 24 Feb 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.19.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many critical bug fixes, including &lt;strong&gt;some data&#xA;loss issues&lt;/strong&gt;. The release also introduces an &lt;strong&gt;incompatible change&lt;/strong&gt; by&#xA;disabling the file append API&#xA;(&lt;a href=&#34;http://issues.apache.org/jira/browse/HADOOP-5224&#34;&gt;HADOOP-5224&lt;/a&gt;) until&#xA;it can be stabilized.&lt;/p&gt;</description>
+      <description>This release contains many critical bug fixes, including some data loss issues. The release also introduces an incompatible change by disabling the file append API (HADOOP-5224) until it can be stabilized.
+See the Hadoop 0.19.1 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.18.3 available</title>
       <link>https://hadoop.apache.org/release/0.18.3.html</link>
       <pubDate>Thu, 29 Jan 2009 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.18.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains many critical bug fixes.
+See the Hadoop 0.18.3 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.19.0 available</title>
       <link>https://hadoop.apache.org/release/0.19.0.html</link>
       <pubDate>Fri, 21 Nov 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.19.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.19.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.18.2 available</title>
       <link>https://hadoop.apache.org/release/0.18.2.html</link>
       <pubDate>Mon, 03 Nov 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.18.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.18.2 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.18.1 available</title>
       <link>https://hadoop.apache.org/release/0.18.1.html</link>
       <pubDate>Wed, 17 Sep 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.18.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.18.1 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.18.0 available</title>
       <link>https://hadoop.apache.org/release/0.18.0.html</link>
       <pubDate>Fri, 22 Aug 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.18.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.18.0 Release Notes for details. Alternatively, you can look at the complete change log for this release or the Jira issue log for all releases.</description>
     </item>
+    
     <item>
       <title>release 0.17.2 available</title>
       <link>https://hadoop.apache.org/release/0.17.2.html</link>
       <pubDate>Tue, 19 Aug 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.17.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains several critical bug fixes.&lt;/p&gt;</description>
+      <description>This release contains several critical bug fixes.
+See the Hadoop 0.17.2 Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.17.1 available</title>
       <link>https://hadoop.apache.org/release/0.17.1.html</link>
       <pubDate>Mon, 23 Jun 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.17.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.17.1 Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.17.0 available</title>
       <link>https://hadoop.apache.org/release/0.17.0.html</link>
       <pubDate>Tue, 20 May 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.17.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the Hadoop 0.17.0 Release Notes for details.</description>
     </item>
+    
     <item>
       <title>release 0.16.4 available</title>
       <link>https://hadoop.apache.org/release/0.16.4.html</link>
       <pubDate>Mon, 05 May 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes 4 critical bugs in release 0.16.3.&lt;/p&gt;</description>
+      <description>This release fixes 4 critical bugs in release 0.16.3.</description>
     </item>
+    
     <item>
       <title>release 0.16.3 available</title>
       <link>https://hadoop.apache.org/release/0.16.3.html</link>
       <pubDate>Wed, 16 Apr 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.16.2.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.16.2.</description>
     </item>
+    
     <item>
       <title>release 0.16.2 available</title>
       <link>https://hadoop.apache.org/release/0.16.2.html</link>
       <pubDate>Wed, 02 Apr 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.16.1.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.16.1.
+HBase has been removed from this release. HBase releases are now maintained at https://hadoop.apache.org/hbase/</description>
     </item>
+    
     <item>
       <title>release 0.16.1 available</title>
       <link>https://hadoop.apache.org/release/0.16.1.html</link>
       <pubDate>Thu, 13 Mar 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.16.0.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.16.0.
+HBase releases are now maintained at https://hadoop.apache.org/hbase/</description>
     </item>
+    
     <item>
       <title>release 0.16.0 available</title>
       <link>https://hadoop.apache.org/release/0.16.0.html</link>
       <pubDate>Thu, 07 Feb 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.16.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+See the release notes (above) for details.
+When upgrading an existing HDFS filesystem to a 0.16.x release from an earlier release, you should first start HDFS with &amp;lsquo;bin/start-dfs.sh -upgrade&amp;rsquo;. See the Hadoop Upgrade page for details.</description>
     </item>
+    
     <item>
       <title>release 0.15.3 available</title>
       <link>https://hadoop.apache.org/release/0.15.3.html</link>
       <pubDate>Fri, 18 Jan 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.15.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.15.3.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.15.3.</description>
     </item>
+    
     <item>
       <title>release 0.15.2 available</title>
       <link>https://hadoop.apache.org/release/0.15.2.html</link>
       <pubDate>Wed, 02 Jan 2008 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.15.2.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.15.1.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.15.1.</description>
     </item>
+    
     <item>
       <title>release 0.15.1 available</title>
       <link>https://hadoop.apache.org/release/0.15.1.html</link>
       <pubDate>Tue, 27 Nov 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.15.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.15.0.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.15.0.</description>
     </item>
+    
     <item>
       <title>release 0.14.4 available</title>
       <link>https://hadoop.apache.org/release/0.14.4.html</link>
       <pubDate>Mon, 26 Nov 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.14.4.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.14.3.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.14.3.</description>
     </item>
+    
     <item>
       <title>release 0.15.0 available</title>
       <link>https://hadoop.apache.org/release/0.15.0.html</link>
       <pubDate>Mon, 29 Oct 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.15.0.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release contains many improvements, new features, bug fixes and&#xA;optimizations.&lt;/p&gt;</description>
+      <description>This release contains many improvements, new features, bug fixes and optimizations.
+Notably, this contains the first working version of HBase.
+See the release notes (above) for details.
+When upgrading an existing HDFS filesystem to a 0.15.x release from an earlier release, you should first start HDFS with &amp;lsquo;bin/start-dfs.sh -upgrade&amp;rsquo;. See the Hadoop Upgrade page for details.</description>
     </item>
+    
     <item>
       <title>release 0.14.3 available</title>
       <link>https://hadoop.apache.org/release/0.14.3.html</link>
       <pubDate>Fri, 19 Oct 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.14.3.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;This release fixes critical bugs in release 0.14.2.&lt;/p&gt;</description>
+      <description>This release fixes critical bugs in release 0.14.2.</description>
     </item>
+    
     <item>
       <title>release 0.14.1 available</title>
       <link>https://hadoop.apache.org/release/0.14.1.html</link>
       <pubDate>Tue, 04 Sep 2007 00:00:00 +0000</pubDate>
+      
       <guid>https://hadoop.apache.org/release/0.14.1.html</guid>
-      <description>&lt;!---&#xA;  Licensed under the Apache License, Version 2.0 (the &#34;License&#34;);&#xA;  you may not use this file except in compliance with the License.&#xA;  You may obtain a copy of the License at&#xA;&#xA;   http://www.apache.org/licenses/LICENSE-2.0&#xA;&#xA;  Unless required by applicable law or agreed to in writing, software&#xA;  distributed under the License is distributed on an &#34;AS IS&#34; BASIS,&#xA;  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#xA;  See the License for the specific language governing permissions and&#xA;  limitations under the License. See accompanying LICENSE file.&#xA;--&gt;&#xA;&lt;p&gt;New features in release 0.14 include:&lt;/p&gt;</description>
+      <description>New features in release 0.14 include:
+Better checksums in HDFS. Checksums are no longer stored in parallel HDFS files, but are stored directly by datanodes alongside blocks. This is more efficient for the namenode and also improves data integrity. Pipes: A C++ API for MapReduce Eclipse Plugin, including HDFS browsing, job monitoring, etc. File modification times in HDFS. There are many other improvements, bug fixes, optimizations and new features. Performance and reliability are better than ever.</description>
     </item>
+    
   </channel>
 </rss>

--- a/content/release/page/10.html
+++ b/content/release/page/10.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -482,7 +485,7 @@ releases</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -493,12 +496,24 @@ releases</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/11.html
+++ b/content/release/page/11.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -428,7 +431,7 @@ optimizations.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -439,12 +442,24 @@ optimizations.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/12.html
+++ b/content/release/page/12.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -424,7 +427,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -435,12 +438,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/2.html
+++ b/content/release/page/2.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -426,7 +429,7 @@ detail the changes since 3.1.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -437,12 +440,24 @@ detail the changes since 3.1.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/3.html
+++ b/content/release/page/3.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -454,7 +457,7 @@ detail the changes since 3.0.0.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -465,12 +468,24 @@ detail the changes since 3.0.0.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/4.html
+++ b/content/release/page/4.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -471,7 +474,7 @@ release in the 2.8.x line.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -482,12 +485,24 @@ release in the 2.8.x line.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/5.html
+++ b/content/release/page/5.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -434,7 +437,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -445,12 +448,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/6.html
+++ b/content/release/page/6.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -538,7 +541,7 @@ for details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -549,12 +552,24 @@ for details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/7.html
+++ b/content/release/page/7.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -476,7 +479,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -487,12 +490,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/8.html
+++ b/content/release/page/8.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -462,7 +465,7 @@ details.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -473,12 +476,24 @@ details.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/release/page/9.html
+++ b/content/release/page/9.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -500,7 +503,7 @@ ChainMapper/Reducer.</li>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -511,12 +514,24 @@ ChainMapper/Reducer.</li>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/releases.html
+++ b/content/releases.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -378,7 +381,7 @@ page</a>.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -389,12 +392,24 @@ page</a>.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/tags.html
+++ b/content/tags.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -162,7 +165,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -173,12 +176,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/tags/index.xml
+++ b/content/tags/index.xml
@@ -4,9 +4,8 @@
     <title>Tags on Apache Hadoop</title>
     <link>https://hadoop.apache.org/tags.html</link>
     <description>Recent content in Tags on Apache Hadoop</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <copyright>Copyright © 2006-{year} The Apache Software Foundation</copyright>
-    <atom:link href="https://hadoop.apache.org/tags/index.xml" rel="self" type="application/rss+xml" />
+    <copyright>Copyright © 2006-{year} The Apache Software Foundation</copyright><atom:link href="https://hadoop.apache.org/tags/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/content/version_control.html
+++ b/content/version_control.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -172,7 +175,7 @@
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -183,12 +186,24 @@
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/versioning.html
+++ b/content/versioning.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -245,7 +248,7 @@ preserves the monotonicity of releases.</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -256,12 +259,24 @@ preserves the monotonicity of releases.</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/content/who.html
+++ b/content/who.html
@@ -10,7 +10,7 @@
     <meta name="description" content="">
     <meta name="author" content="">
     <link rel="icon" href="/favicon.ico">
-    <base href="https://hadoop.apache.org/">
+    <base href="https://hadoop.apache.org">
     <title>Apache Hadoop</title>
 
     
@@ -116,10 +116,20 @@
        
           
             <li class="dropdown ">
-             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Help <span class="caret"></span></a>
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Apache Software Foundation <span class="caret"></span></a>
              <ul class="dropdown-menu">
                
+                  <li ><a href="https://www.apache.org">Apache Home</a></li>
+               
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
+               
+                  <li ><a href="https://events.apache.org">Event</a></li>
+               
+                  <li ><a href="https://www.apache.org/licenses">License</a></li>
+               
+                  <li ><a href="https://privacy.apache.org/policies/privacy-policy-public.html">Privacy Policy</a></li>
+               
+                  <li ><a href="https://www.apache.org/security">Security</a></li>
                
                   <li ><a href="https://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                
@@ -130,13 +140,6 @@
            </li>
           
        
-     </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
      </ul>
    </div>
 
@@ -171,766 +174,766 @@ also learn from common mistakes and as a community we all grow together.</p>
 <p>The Hadoop Project Management Committee contains (in alphabetical
 order):</p>
 <table>
-  <thead>
-      <tr>
-          <th>username</th>
-          <th>name</th>
-          <th>organization</th>
-          <th>roles</th>
-          <th>timezone</th>
-      </tr>
-  </thead>
-  <tbody>
-      <tr>
-          <td>aajisaka</td>
-          <td>Akira Ajisaka</td>
-          <td>AWS</td>
-          <td></td>
-          <td>+9</td>
-      </tr>
-      <tr>
-          <td>acmurthy</td>
-          <td><a href="http://people.apache.org/~acmurthy">Arun C Murthy</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>aengineer</td>
-          <td>Anu Engineer</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>amareshwari</td>
-          <td>Amareshwari Sriramadasu</td>
-          <td>InMobi</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>arp</td>
-          <td><a href="http://people.apache.org/~arp">Arpit Agarwal</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>asuresh</td>
-          <td>Arun Suresh</td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>atm</td>
-          <td><a href="http://people.apache.org/~atm">Aaron T. Myers</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ayushsaxena</td>
-          <td>Ayush Saxena</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>bikas</td>
-          <td>Bikas Saha</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>billie</td>
-          <td>Billie Rinaldi</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-5</td>
-      </tr>
-      <tr>
-          <td>bibinchundatt</td>
-          <td>Bibin A Chundatt</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>bobby</td>
-          <td>Robert(Bobby) Evans</td>
-          <td>NVIDIA</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>brahma</td>
-          <td>Brahma Reddy Battula</td>
-          <td>Huawei</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>brandonli</td>
-          <td>Brandon Li</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cdouglas</td>
-          <td><a href="http://people.apache.org/~cdouglas">Chris Douglas</a></td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cliang</td>
-          <td>Chen Liang</td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cmccabe</td>
-          <td><a href="http://www.club.cc.cmu.edu/~cmccabe">Colin Patrick McCabe</a></td>
-          <td>Cloudera</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cnauroth</td>
-          <td><a href="https://github.com/cnauroth">Chris Nauroth</a></td>
-          <td>Google</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cutting</td>
-          <td><a href="http://blog.lucene.com/">Doug Cutting</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>daryn</td>
-          <td>Daryn Sharp</td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>ddas</td>
-          <td><a href="http://people.apache.org/~ddas">Devaraj Das</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>devaraj</td>
-          <td>Devaraj K</td>
-          <td>Intel</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>dhruba</td>
-          <td><a href="http://people.apache.org/~dhruba">Dhruba Borthakur</a></td>
-          <td>Facebook</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ebadger</td>
-          <td>Eric Badger</td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>eli</td>
-          <td><a href="http://people.apache.org/~eli">Eli Collins</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>enis</td>
-          <td><a href="http://people.apache.org/~enis">Enis Soztutar</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>epayne</td>
-          <td><a href="http://people.apache.org/~epayne">Eric Payne</a></td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>gkesavan</td>
-          <td><a href="http://people.apache.org/~gkesavan">Giridharan Kesavan</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>haibochen</td>
-          <td>Haibo Chen</td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>hairong</td>
-          <td>Hairong Kuang</td>
-          <td>Facebook</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>hexiaoqiao</td>
-          <td><a href="http://hexiaoqiao.github.io">He Xiaoqiao</a></td>
-          <td>Meituan</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>hitesh</td>
-          <td>Hitesh Shah</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>inigoiri</td>
-          <td>Íñigo Goiri</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>iwasakims</td>
-          <td>Masatake Iwasaki</td>
-          <td>NTT DATA</td>
-          <td></td>
-          <td>+9</td>
-      </tr>
-      <tr>
-          <td>jeagles</td>
-          <td><a href="http://people.apache.org/~jeagles">Jonathan Eagles</a></td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>jghoman</td>
-          <td><a href="http://people.apache.org/~jghoman">Jakob Homan</a></td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jhung</td>
-          <td>Jonathan Hung</td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jianhe</td>
-          <td><a href="http://people.apache.org/~jianhe">Jian He</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jing9</td>
-          <td>Jing Zhao</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jitendra</td>
-          <td><a href="http://people.apache.org/~jitendra">Jitendra Nath Pandey</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jlowe</td>
-          <td>Jason Lowe</td>
-          <td>NVIDIA</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>jzhuge</td>
-          <td>John Zhuge</td>
-          <td>Netflix</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>junping_du</td>
-          <td>Junping Du</td>
-          <td>Datastrato</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>kasha</td>
-          <td><a href="http://people.apache.org/~kasha">Karthik Kambatla</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>kihwal</td>
-          <td><a href="http://people.apache.org/~kihwal">Kihwal Lee</a></td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>kkaranasos</td>
-          <td><a href="http://www.microsoft.com/en-us/research/people/kokarana">Konstantinos Karanasos</a></td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>lei</td>
-          <td><a href="http://people.apache.org/~lei">Lei Xu</a></td>
-          <td>Cruise Automation</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>liuml07</td>
-          <td><a href="http://people.apache.org/~liuml07">Mingliang Liu</a></td>
-          <td>Salesforce</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ljain</td>
-          <td><a href="https://github.com/lokeshj1703">Lokesh Jain</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>llu</td>
-          <td><a href="http://people.apache.org/~llu">Luke Lu</a></td>
-          <td>VMware</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>mahadev</td>
-          <td>Mahadev Konar</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>mattf</td>
-          <td>Matt Foley</td>
-          <td>Apple</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>mingma</td>
-          <td>Ming Ma</td>
-          <td>Twitter</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>msingh</td>
-          <td>Mukul Kumar Singh</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>naganarasimha_gr</td>
-          <td><a href="http://people.apache.org/~naganarasimha_gr/">Naganarasimha G R</a></td>
-          <td>SCB</td>
-          <td></td>
-          <td>+8.0</td>
-      </tr>
-      <tr>
-          <td>nanda</td>
-          <td>Nanda kumar</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>nigel</td>
-          <td>Nigel Daley</td>
-          <td>Pinterest</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>omalley</td>
-          <td><a href="http://people.apache.org/~omalley">Owen O'Malley</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ozawa</td>
-          <td><a href="http://people.apache.org/~ozawa">Tsuyoshi Ozawa</a></td>
-          <td>NTT</td>
-          <td></td>
-          <td>+9</td>
-      </tr>
-      <tr>
-          <td>phunt</td>
-          <td><a href="http://people.apache.org/~phunt">Patrick Hunt</a></td>
-          <td>Cloudera</td>
-          <td>ZooKeeper</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>rangadi</td>
-          <td>Raghu Angadi</td>
-          <td>Twitter</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>rchiang</td>
-          <td>Ray Chiang</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>rkanter</td>
-          <td>Robert Kanter</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>rohithsharmaks</td>
-          <td>Rohith Sharma K S</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>sharad</td>
-          <td>Sharad Agarwal</td>
-          <td>InMobi</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>shv</td>
-          <td><a href="http://people.apache.org/~shv">Konstantin Shvachko</a></td>
-          <td>LinkedIn</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sammichen</td>
-          <td>Sammi Chen</td>
-          <td>Tencent</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>sandy</td>
-          <td><a href="http://people.apache.org/~sandy">Sandy Ryza</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>shashikant</td>
-          <td>Shashikant Banerjee</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>sjlee</td>
-          <td><a href="http://people.apache.org/~sjlee">Sangjin Lee</a></td>
-          <td>PayPal</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>snemeth</td>
-          <td><a href="https://github.com/szilard-nemeth">Szilard Nemeth</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+1</td>
-      </tr>
-      <tr>
-          <td>sradia</td>
-          <td><a href="http://people.apache.org/~sradia">Sanjay Radia</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sseth</td>
-          <td>Siddharth Seth</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>stack</td>
-          <td>Michael Stack</td>
-          <td>Apple</td>
-          <td>HBase</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>stevel</td>
-          <td>Steve Loughran</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>0</td>
-      </tr>
-      <tr>
-          <td>subru</td>
-          <td>Subru Krishnan</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sunilg</td>
-          <td>Sunil Govindan</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>surendralilhore</td>
-          <td>Surendra Singh Lilhore</td>
-          <td>Microsoft</td>
-          <td>HDFS</td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>suresh</td>
-          <td><a href="http://people.apache.org/~suresh">Suresh Srinivas</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>szetszwo</td>
-          <td><a href="http://people.apache.org/~szetszwo">Tsz Wo (Nicholas) Sze</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>tasanuma</td>
-          <td><a href="http://people.apache.org/~tasanuma">Takanobu Asanuma</a></td>
-          <td>Yahoo! JAPAN</td>
-          <td></td>
-          <td>+9</td>
-      </tr>
-      <tr>
-          <td>templedf</td>
-          <td>Daniel Templeton</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>tgraves</td>
-          <td>Thomas Graves</td>
-          <td>NVIDIA</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>todd</td>
-          <td><a href="http://people.apache.org/~todd">Todd Lipcon</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>tomwhite</td>
-          <td><a href="http://weblogs.java.net/blog/tomwhite/">Tom White</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>tucu</td>
-          <td>Alejandro Abdelnur</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>umamahesh</td>
-          <td><a href="https://people.apache.org/~umamahesh/umamahesh.html">Uma Maheswara Rao G</a></td>
-          <td>Intel</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>varunsaxena</td>
-          <td><a href="http://people.apache.org/~varunsaxena">Varun Saxena</a></td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>vinayakumarb</td>
-          <td><a href="https://people.apache.org/~vinayakumarb/">Vinayakumar B</a></td>
-          <td>Google</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>vinodkv</td>
-          <td>Vinod Kumar Vavilapalli</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>vvasudev</td>
-          <td>Varun Vasudev</td>
-          <td></td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>yhemanth</td>
-          <td>Hemanth Yamijala</td>
-          <td></td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>wang</td>
-          <td>Andrew Wang</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>wangda</td>
-          <td>Wangda Tan</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>wheat9</td>
-          <td><a href="http://haohui.me">Haohui Mai</a></td>
-          <td>Uber</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>wwei</td>
-          <td><a href="https://yangwwei.github.io/">Weiwei Yang</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>xgong</td>
-          <td><a href="http://people.apache.org/~xgong">Xuan Gong</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>xiao</td>
-          <td>Xiao Chen</td>
-          <td>Netflix</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>xyao</td>
-          <td><a href="http://people.apache.org/~xyao">Xiaoyu Yao</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>yjzhangal</td>
-          <td><a href="http://people.apache.org/~yjzhangal">Yongjun Zhang</a></td>
-          <td>Pinterest</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>yliu</td>
-          <td><a href="http://people.apache.org/~yliu">Yi Liu</a></td>
-          <td>Intel</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>yqlin</td>
-          <td><a href="https://github.com/linyiqun">Yiqun Lin</a></td>
-          <td>EBay</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>yufei</td>
-          <td><a href="http://people.apache.org/~yufei">Yufei Gu</a></td>
-          <td>Apple</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>zhz</td>
-          <td><a href="http://zhe-thoughts.github.io/about/">Zhe Zhang</a></td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>zjshen</td>
-          <td><a href="http://people.apache.org/~zjshen">Zhijie Shen</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>zshao</td>
-          <td>Zheng Shao</td>
-          <td>Facebook</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ztang</td>
-          <td>Zhankun Tang</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-  </tbody>
+<thead>
+<tr>
+<th>username</th>
+<th>name</th>
+<th>organization</th>
+<th>roles</th>
+<th>timezone</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>aajisaka</td>
+<td>Akira Ajisaka</td>
+<td>AWS</td>
+<td></td>
+<td>+9</td>
+</tr>
+<tr>
+<td>acmurthy</td>
+<td><a href="http://people.apache.org/~acmurthy">Arun C Murthy</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>aengineer</td>
+<td>Anu Engineer</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>amareshwari</td>
+<td>Amareshwari Sriramadasu</td>
+<td>InMobi</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>arp</td>
+<td><a href="http://people.apache.org/~arp">Arpit Agarwal</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>asuresh</td>
+<td>Arun Suresh</td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>atm</td>
+<td><a href="http://people.apache.org/~atm">Aaron T. Myers</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ayushsaxena</td>
+<td>Ayush Saxena</td>
+<td>Cloudera</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>bikas</td>
+<td>Bikas Saha</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>billie</td>
+<td>Billie Rinaldi</td>
+<td>Microsoft</td>
+<td></td>
+<td>-5</td>
+</tr>
+<tr>
+<td>bibinchundatt</td>
+<td>Bibin A Chundatt</td>
+<td>Microsoft</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>bobby</td>
+<td>Robert(Bobby) Evans</td>
+<td>NVIDIA</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>brahma</td>
+<td>Brahma Reddy Battula</td>
+<td>Huawei</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>brandonli</td>
+<td>Brandon Li</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cdouglas</td>
+<td><a href="http://people.apache.org/~cdouglas">Chris Douglas</a></td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cliang</td>
+<td>Chen Liang</td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cmccabe</td>
+<td><a href="http://www.club.cc.cmu.edu/~cmccabe">Colin Patrick McCabe</a></td>
+<td>Cloudera</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cnauroth</td>
+<td><a href="https://github.com/cnauroth">Chris Nauroth</a></td>
+<td>Google</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cutting</td>
+<td><a href="http://blog.lucene.com/">Doug Cutting</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>daryn</td>
+<td>Daryn Sharp</td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>ddas</td>
+<td><a href="http://people.apache.org/~ddas">Devaraj Das</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>devaraj</td>
+<td>Devaraj K</td>
+<td>Intel</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>dhruba</td>
+<td><a href="http://people.apache.org/~dhruba">Dhruba Borthakur</a></td>
+<td>Facebook</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ebadger</td>
+<td>Eric Badger</td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>eli</td>
+<td><a href="http://people.apache.org/~eli">Eli Collins</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>enis</td>
+<td><a href="http://people.apache.org/~enis">Enis Soztutar</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>epayne</td>
+<td><a href="http://people.apache.org/~epayne">Eric Payne</a></td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>gkesavan</td>
+<td><a href="http://people.apache.org/~gkesavan">Giridharan Kesavan</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>haibochen</td>
+<td>Haibo Chen</td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>hairong</td>
+<td>Hairong Kuang</td>
+<td>Facebook</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>hexiaoqiao</td>
+<td><a href="http://hexiaoqiao.github.io">He Xiaoqiao</a></td>
+<td>Meituan</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>hitesh</td>
+<td>Hitesh Shah</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>inigoiri</td>
+<td>Íñigo Goiri</td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>iwasakims</td>
+<td>Masatake Iwasaki</td>
+<td>NTT DATA</td>
+<td></td>
+<td>+9</td>
+</tr>
+<tr>
+<td>jeagles</td>
+<td><a href="http://people.apache.org/~jeagles">Jonathan Eagles</a></td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>jghoman</td>
+<td><a href="http://people.apache.org/~jghoman">Jakob Homan</a></td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jhung</td>
+<td>Jonathan Hung</td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jianhe</td>
+<td><a href="http://people.apache.org/~jianhe">Jian He</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jing9</td>
+<td>Jing Zhao</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jitendra</td>
+<td><a href="http://people.apache.org/~jitendra">Jitendra Nath Pandey</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jlowe</td>
+<td>Jason Lowe</td>
+<td>NVIDIA</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>jzhuge</td>
+<td>John Zhuge</td>
+<td>Netflix</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>junping_du</td>
+<td>Junping Du</td>
+<td>Datastrato</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>kasha</td>
+<td><a href="http://people.apache.org/~kasha">Karthik Kambatla</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>kihwal</td>
+<td><a href="http://people.apache.org/~kihwal">Kihwal Lee</a></td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>kkaranasos</td>
+<td><a href="http://www.microsoft.com/en-us/research/people/kokarana">Konstantinos Karanasos</a></td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>lei</td>
+<td><a href="http://people.apache.org/~lei">Lei Xu</a></td>
+<td>Cruise Automation</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>liuml07</td>
+<td><a href="http://people.apache.org/~liuml07">Mingliang Liu</a></td>
+<td>Salesforce</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ljain</td>
+<td><a href="https://github.com/lokeshj1703">Lokesh Jain</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>llu</td>
+<td><a href="http://people.apache.org/~llu">Luke Lu</a></td>
+<td>VMware</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>mahadev</td>
+<td>Mahadev Konar</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>mattf</td>
+<td>Matt Foley</td>
+<td>Apple</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>mingma</td>
+<td>Ming Ma</td>
+<td>Twitter</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>msingh</td>
+<td>Mukul Kumar Singh</td>
+<td>Hortonworks</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>naganarasimha_gr</td>
+<td><a href="http://people.apache.org/~naganarasimha_gr/">Naganarasimha G R</a></td>
+<td>SCB</td>
+<td></td>
+<td>+8.0</td>
+</tr>
+<tr>
+<td>nanda</td>
+<td>Nanda kumar</td>
+<td>Hortonworks</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>nigel</td>
+<td>Nigel Daley</td>
+<td>Pinterest</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>omalley</td>
+<td><a href="http://people.apache.org/~omalley">Owen O'Malley</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ozawa</td>
+<td><a href="http://people.apache.org/~ozawa">Tsuyoshi Ozawa</a></td>
+<td>NTT</td>
+<td></td>
+<td>+9</td>
+</tr>
+<tr>
+<td>phunt</td>
+<td><a href="http://people.apache.org/~phunt">Patrick Hunt</a></td>
+<td>Cloudera</td>
+<td>ZooKeeper</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>rangadi</td>
+<td>Raghu Angadi</td>
+<td>Twitter</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>rchiang</td>
+<td>Ray Chiang</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>rkanter</td>
+<td>Robert Kanter</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>rohithsharmaks</td>
+<td>Rohith Sharma K S</td>
+<td>Hortonworks</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>sharad</td>
+<td>Sharad Agarwal</td>
+<td>InMobi</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>shv</td>
+<td><a href="http://people.apache.org/~shv">Konstantin Shvachko</a></td>
+<td>LinkedIn</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sammichen</td>
+<td>Sammi Chen</td>
+<td>Tencent</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>sandy</td>
+<td><a href="http://people.apache.org/~sandy">Sandy Ryza</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>shashikant</td>
+<td>Shashikant Banerjee</td>
+<td>Cloudera</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>sjlee</td>
+<td><a href="http://people.apache.org/~sjlee">Sangjin Lee</a></td>
+<td>PayPal</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>snemeth</td>
+<td><a href="https://github.com/szilard-nemeth">Szilard Nemeth</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+1</td>
+</tr>
+<tr>
+<td>sradia</td>
+<td><a href="http://people.apache.org/~sradia">Sanjay Radia</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sseth</td>
+<td>Siddharth Seth</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>stack</td>
+<td>Michael Stack</td>
+<td>Apple</td>
+<td>HBase</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>stevel</td>
+<td>Steve Loughran</td>
+<td>Cloudera</td>
+<td></td>
+<td>0</td>
+</tr>
+<tr>
+<td>subru</td>
+<td>Subru Krishnan</td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sunilg</td>
+<td>Sunil Govindan</td>
+<td>Cloudera</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>surendralilhore</td>
+<td>Surendra Singh Lilhore</td>
+<td>Microsoft</td>
+<td>HDFS</td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>suresh</td>
+<td><a href="http://people.apache.org/~suresh">Suresh Srinivas</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>szetszwo</td>
+<td><a href="http://people.apache.org/~szetszwo">Tsz Wo (Nicholas) Sze</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>tasanuma</td>
+<td><a href="http://people.apache.org/~tasanuma">Takanobu Asanuma</a></td>
+<td>Yahoo! JAPAN</td>
+<td></td>
+<td>+9</td>
+</tr>
+<tr>
+<td>templedf</td>
+<td>Daniel Templeton</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>tgraves</td>
+<td>Thomas Graves</td>
+<td>NVIDIA</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>todd</td>
+<td><a href="http://people.apache.org/~todd">Todd Lipcon</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>tomwhite</td>
+<td><a href="http://weblogs.java.net/blog/tomwhite/">Tom White</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>tucu</td>
+<td>Alejandro Abdelnur</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>umamahesh</td>
+<td><a href="https://people.apache.org/~umamahesh/umamahesh.html">Uma Maheswara Rao G</a></td>
+<td>Intel</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>varunsaxena</td>
+<td><a href="http://people.apache.org/~varunsaxena">Varun Saxena</a></td>
+<td>LinkedIn</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>vinayakumarb</td>
+<td><a href="https://people.apache.org/~vinayakumarb/">Vinayakumar B</a></td>
+<td>Google</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>vinodkv</td>
+<td>Vinod Kumar Vavilapalli</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>vvasudev</td>
+<td>Varun Vasudev</td>
+<td></td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>yhemanth</td>
+<td>Hemanth Yamijala</td>
+<td></td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>wang</td>
+<td>Andrew Wang</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>wangda</td>
+<td>Wangda Tan</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>wheat9</td>
+<td><a href="http://haohui.me">Haohui Mai</a></td>
+<td>Uber</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>wwei</td>
+<td><a href="https://yangwwei.github.io/">Weiwei Yang</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>xgong</td>
+<td><a href="http://people.apache.org/~xgong">Xuan Gong</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>xiao</td>
+<td>Xiao Chen</td>
+<td>Netflix</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>xyao</td>
+<td><a href="http://people.apache.org/~xyao">Xiaoyu Yao</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>yjzhangal</td>
+<td><a href="http://people.apache.org/~yjzhangal">Yongjun Zhang</a></td>
+<td>Pinterest</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>yliu</td>
+<td><a href="http://people.apache.org/~yliu">Yi Liu</a></td>
+<td>Intel</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>yqlin</td>
+<td><a href="https://github.com/linyiqun">Yiqun Lin</a></td>
+<td>EBay</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>yufei</td>
+<td><a href="http://people.apache.org/~yufei">Yufei Gu</a></td>
+<td>Apple</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>zhz</td>
+<td><a href="http://zhe-thoughts.github.io/about/">Zhe Zhang</a></td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>zjshen</td>
+<td><a href="http://people.apache.org/~zjshen">Zhijie Shen</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>zshao</td>
+<td>Zheng Shao</td>
+<td>Facebook</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ztang</td>
+<td>Zhankun Tang</td>
+<td>Cloudera</td>
+<td></td>
+<td>+8</td>
+</tr>
+</tbody>
 </table>
 <p>Emeritus Hadoop PMC Members</p>
 <ul>
@@ -941,1305 +944,1305 @@ order):</p>
 <h2 id="hadoop-committers">Hadoop Committers</h2>
 <p>Hadoop&rsquo;s active committers include:</p>
 <table>
-  <thead>
-      <tr>
-          <th>username</th>
-          <th>name</th>
-          <th>organization</th>
-          <th>roles</th>
-          <th>timezone</th>
-      </tr>
-  </thead>
-  <tbody>
-      <tr>
-          <td>aajisaka</td>
-          <td>Akira Ajisaka</td>
-          <td>AWS</td>
-          <td></td>
-          <td>+9</td>
-      </tr>
-      <tr>
-          <td>ab</td>
-          <td>Andrzej Bialecki</td>
-          <td>Getopt</td>
-          <td></td>
-          <td>+1</td>
-      </tr>
-      <tr>
-          <td>abmodi</td>
-          <td>Abhishek Modi</td>
-          <td>Google</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>acmurthy</td>
-          <td><a href="http://people.apache.org/~acmurthy">Arun C Murthy</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>adhoot</td>
-          <td>Anubhav Dhoot</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>aengineer</td>
-          <td>Anu Engineer</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ajay</td>
-          <td>Ajay Kumar</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>amareshwari</td>
-          <td><a href="http://people.apache.org/~amareshwari">Amareshwari Sriramadasu</a></td>
-          <td>InMobi</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>amarrk</td>
-          <td><a href="http://people.apache.org/~amarrk">Amar Ramesh Kamat</a></td>
-          <td>Yahoo!</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>arp</td>
-          <td><a href="http://people.apache.org/~arp">Arpit Agarwal</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>arpit</td>
-          <td><a href="http://people.apache.org/~arpit">Arpit Gupta</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>asuresh</td>
-          <td>Arun Suresh</td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>atm</td>
-          <td><a href="http://people.apache.org/~atm">Aaron T. Myers</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>avijayan</td>
-          <td><a href="https://github.com/avijayanhwx">Aravindan Vijayan</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>aw</td>
-          <td>Allen Wittenauer</td>
-          <td>Effective Machines</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ayushsaxena</td>
-          <td>Ayush Saxena</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>benoy</td>
-          <td><a href="http://people.apache.org/~benoy">Benoy Antony</a></td>
-          <td>eBay</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>bharat</td>
-          <td>Bharat Viswanadham</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>bibinchundatt</td>
-          <td>Bibin A Chundatt</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>bikas</td>
-          <td>Bikas Saha</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>billie</td>
-          <td>Billie Rinaldi</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-5</td>
-      </tr>
-      <tr>
-          <td>bobby</td>
-          <td>Robert(Bobby) Evans</td>
-          <td>NVIDIA</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>boryas</td>
-          <td><a href="http://people.apache.org/~boryas">Boris Shkolnik</a></td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>botong</td>
-          <td>Botong Huang</td>
-          <td>Alibaba</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>brahma</td>
-          <td>Brahma Reddy Battula</td>
-          <td>Huawei</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>brandonli</td>
-          <td>Brandon Li</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>bteke</td>
-          <td><a href="https://github.com/brumi1024">Benjamin Teke</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+1</td>
-      </tr>
-      <tr>
-          <td>busbey</td>
-          <td>Sean Busbey</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>cdouglas</td>
-          <td>Chris Douglas</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cliang</td>
-          <td>Chen Liang</td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cmccabe</td>
-          <td><a href="http://www.club.cc.cmu.edu/~cmccabe">Colin Patrick McCabe</a></td>
-          <td>Cloudera</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cnauroth</td>
-          <td><a href="https://github.com/cnauroth">Chris Nauroth</a></td>
-          <td>Google</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cos</td>
-          <td><a href="http://people.apache.org/~cos">Konstantin Boudnik</a></td>
-          <td>WANdisco</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>csingh</td>
-          <td>Chandni Singh</td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ctrezzo</td>
-          <td>Chris Trezzo</td>
-          <td>Twitter</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>curino</td>
-          <td>Carlo Curino</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>cutting</td>
-          <td><a href="http://blog.lucene.com/">Doug Cutting</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>daryn</td>
-          <td>Daryn Sharp</td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>ddas</td>
-          <td><a href="http://people.apache.org/~ddas">Devaraj Das</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>devaraj</td>
-          <td>Devaraj K</td>
-          <td>Intel</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>dhruba</td>
-          <td><a href="http://people.apache.org/~dhruba">Dhruba Borthakur</a></td>
-          <td>Facebook</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>dineshc</td>
-          <td><a href="https://www.linkedin.com/in/dineshchitlangia/">Dinesh Chitlangia</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-5</td>
-      </tr>
-      <tr>
-          <td>dmollitor</td>
-          <td><a href="https://www.linkedin.com/in/david-mollitor-a17b779/">David Mollitor</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-5</td>
-      </tr>
-      <tr>
-          <td>drankye</td>
-          <td><a href="http://people.apache.org/~drankye">Kai Zheng</a></td>
-          <td>Intel</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>ebadger</td>
-          <td>Eric Badger</td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>elek</td>
-          <td><a href="https://github.com/elek">Márton Elek</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+1</td>
-      </tr>
-      <tr>
-          <td>eli</td>
-          <td><a href="http://people.apache.org/~eli">Eli Collins</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>epayne</td>
-          <td><a href="http://people.apache.org/~epayne">Eric Payne</a></td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>enis</td>
-          <td><a href="http://people.apache.org/~enis">Enis Soztutar</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>eyang</td>
-          <td><a href="http://people.apache.org/~eyang">Eric Yang</a></td>
-          <td>IBM</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ferhui</td>
-          <td>Hui Fei</td>
-          <td>Tencent</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>gabota</td>
-          <td><a href="https://github.com/bgaborg">Gabor Bota</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+1</td>
-      </tr>
-      <tr>
-          <td>gaurava</td>
-          <td><a href="https://github.com/GauthamBanasandra">Gautham Banasandra</a></td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>gera</td>
-          <td><a href="https://github.com/gerashegalov">Gera Shegalov</a></td>
-          <td>NVIDIA</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>gifuma</td>
-          <td>Giovanni Matteo Fumarola</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>gkesavan</td>
-          <td><a href="http://people.apache.org/~gkesavan">Giridharan Kesavan</a></td>
-          <td>Hortonworks</td>
-          <td>RE</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>gtcarrera9</td>
-          <td>Li Lu</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>hemanthboyina</td>
-          <td><a href="https://github.com/hemanthboyina">Hemanth Boyina</a></td>
-          <td>Huawei</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>hitesh</td>
-          <td>Hitesh Shah</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>haibochen</td>
-          <td>Haibo Chen</td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>hairong</td>
-          <td><a href="http://people.apache.org/~hairong">Hairong Kuang</a></td>
-          <td>Facebook</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>hanishakoneru</td>
-          <td>Hanisha Koneru</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>harsh</td>
-          <td><a href="http://harshj.com/">Harsh J</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>hexiaoqiao</td>
-          <td><a href="http://hexiaoqiao.github.io">He Xiaoqiao</a></td>
-          <td>Meituan</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>huhaiyang</td>
-          <td><a href="https://github.com/haiyang1987">Haiyang Hu</a></td>
-          <td>Shopee</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>inigoiri</td>
-          <td>Íñigo Goiri</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ivanmi</td>
-          <td>Ivan Mitic</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>iwasakims</td>
-          <td>Masatake Iwasaki</td>
-          <td>NTT DATA</td>
-          <td></td>
-          <td>+9</td>
-      </tr>
-      <tr>
-          <td>jbrennan</td>
-          <td><a href="https://github.com/jbrennan333">Jim Brennan</a></td>
-          <td>NVIDIA</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>jeagles</td>
-          <td><a href="http://people.apache.org/~jeagles">Jonathan Eagles</a></td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>jghoman</td>
-          <td><a href="http://people.apache.org/~jghoman">Jakob Homan</a></td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jhung</td>
-          <td>Jonathan Hung</td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jianhe</td>
-          <td><a href="http://people.apache.org/~jianhe">Jian He</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jing9</td>
-          <td>Jing Zhao</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jitendra</td>
-          <td><a href="http://people.apache.org/~jitendra">Jitendra Nath Pandey</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>jlowe</td>
-          <td>Jason Lowe</td>
-          <td>NVIDIA</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>johan</td>
-          <td><a href="http://people.apache.org/~johan">Johan Oskarsson</a></td>
-          <td>Twitter</td>
-          <td></td>
-          <td>0</td>
-      </tr>
-      <tr>
-          <td>junping_du</td>
-          <td>Junping Du</td>
-          <td>Datastrato</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>jzhuge</td>
-          <td>John Zhuge</td>
-          <td>Netflix</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>kasha</td>
-          <td><a href="http://people.apache.org/~kasha">Karthik Kambatla</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>kihwal</td>
-          <td><a href="http://people.apache.org/~kihwal">Kihwal Lee</a></td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>kkaranasos</td>
-          <td><a href="http://www.microsoft.com/en-us/research/people/kokarana">Konstantinos Karanasos</a></td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>knoguchi</td>
-          <td><a href="http://people.apache.org/~knoguchi">Koji Noguchi</a></td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>kzhang</td>
-          <td>Kan Zhang</td>
-          <td>IBM</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>lei</td>
-          <td><a href="http://people.apache.org/~lei">Lei Xu</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>licheng</td>
-          <td><a href="https://www.linkedin.com/in/licheng1990/">Li Cheng</a></td>
-          <td>Tencent</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>liuml07</td>
-          <td><a href="http://people.apache.org/~liuml07">Mingliang Liu</a></td>
-          <td>Salesforce</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>liuxun</td>
-          <td><a href="https://github.com/xunliu/">Xun Liu</a></td>
-          <td>Tencent</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>ljain</td>
-          <td><a href="https://github.com/lokeshj1703">Lokesh Jain</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>lohit</td>
-          <td><a href="http://people.apache.org/~lohit">Lohit Vijayarenu</a></td>
-          <td>Twitter</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>llu</td>
-          <td><a href="http://people.apache.org/~llu">Luke Lu</a></td>
-          <td>VMware</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>lmccay</td>
-          <td><a href="http://people.apache.org/~lmccay">Larry McCay</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-5</td>
-      </tr>
-      <tr>
-          <td>mackrorysd</td>
-          <td>Sean Mackrory</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-7</td>
-      </tr>
-      <tr>
-          <td>mahadev</td>
-          <td>Mahadev Konar</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>manojpec</td>
-          <td>Manoj Govindassamy</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>matei</td>
-          <td><a href="http://www.cs.berkeley.edu/~matei">Matei Zaharia</a></td>
-          <td>UC Berkeley</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>mattf</td>
-          <td><a href="http://people.apache.org/~mattf">Matthew Foley</a></td>
-          <td>Apple</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>mayank</td>
-          <td><a href="http://people.apache.org/~mayank">Mayank Bansal</a></td>
-          <td>uber</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>molkov</td>
-          <td><a href="http://people.apache.org/~molkov">Dmytro Molkov</a></td>
-          <td>Facebook</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>mukund</td>
-          <td><a href="http://people.apache.org/~mukund">Mukund Madhugiri</a></td>
-          <td>Yahoo!</td>
-          <td>QA</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>mingma</td>
-          <td>Ming Ma</td>
-          <td>Twitter</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>msingh</td>
-          <td>Mukul Kumar Singh</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>naganarasimha_gr</td>
-          <td><a href="http://people.apache.org/~naganarasimha_gr/">Naganarasimha G R</a></td>
-          <td>SCB</td>
-          <td></td>
-          <td>+8.0</td>
-      </tr>
-      <tr>
-          <td>nanda</td>
-          <td>Nanda kumar</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>nigel</td>
-          <td><a href="http://people.apache.org/~nigel">Nigel Daley</a></td>
-          <td>Pinterest</td>
-          <td>QA</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>nroberts</td>
-          <td>Nathan Roberts</td>
-          <td>Verizon Media</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>omalley</td>
-          <td><a href="http://people.apache.org/~omalley">Owen O'Malley</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ozawa</td>
-          <td><a href="http://people.apache.org/~ozawa">Tsuyoshi Ozawa</a></td>
-          <td>NTT</td>
-          <td></td>
-          <td>+9</td>
-      </tr>
-      <tr>
-          <td>prabhujoseph</td>
-          <td>Prabhu Joseph</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>quapaw</td>
-          <td><a href="https://github.com/9uapaw">Andras Gyori</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+1</td>
-      </tr>
-      <tr>
-          <td>rakeshr</td>
-          <td><a href="https://people.apache.org/~rakeshr">Rakesh Radhakrishnan</a></td>
-          <td>Intel</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>rangadi</td>
-          <td><a href="http://people.apache.org/~rangadi">Raghu Angadi</a></td>
-          <td>Twitter</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ramya</td>
-          <td><a href="http://people.apache.org/~ramya">Ramya Sunil</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>raviprak</td>
-          <td><a href="http://people.apache.org/~raviprak">Ravi Prakash</a></td>
-          <td>Altiscale, Inc.</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>rchiang</td>
-          <td>Ray Chiang</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>rkanter</td>
-          <td>Robert Kanter</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>rohithsharmaks</td>
-          <td>Rohith Sharma K S</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>rvs</td>
-          <td><a href="http://people.apache.org/~rvs">Roman Shaposhnik</a></td>
-          <td>Pivotal</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sammichen</td>
-          <td>Sammi Chen</td>
-          <td>Tencent</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>schen</td>
-          <td><a href="http://people.apache.org/~schen">Scott Chun-Yang Chen</a></td>
-          <td>Facebook</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sharad</td>
-          <td>Sharad Agarwal</td>
-          <td>InMobi</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>shv</td>
-          <td><a href="http://people.apache.org/~shv">Konstantin Shvachko</a></td>
-          <td>LinkedIn</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sandy</td>
-          <td><a href="http://people.apache.org/~sandy">Sandy Ryza</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>shashikant</td>
-          <td>Shashikant Banerjee</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>siyao</td>
-          <td><a href="http://people.apache.org/~siyao">Siyao Meng</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sjlee</td>
-          <td><a href="http://people.apache.org/~sjlee">Sangjin Lee</a></td>
-          <td>PayPal</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sradia</td>
-          <td><a href="http://people.apache.org/~sradia">Sanjay Radia</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sreekanth</td>
-          <td>Sreekanth Ramakrishnan</td>
-          <td>InMobi</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>sidharta</td>
-          <td>Sidharta Seethana</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>simbadzina</td>
-          <td><a href="https://github.com/simbadzina">Simbarashe Dzinamarira</a></td>
-          <td>LinkedIn</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>slfan1989</td>
-          <td>Shilun Fan</td>
-          <td>DiDi</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>snemeth</td>
-          <td><a href="https://github.com/szilard-nemeth">Szilard Nemeth</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+1</td>
-      </tr>
-      <tr>
-          <td>sseth</td>
-          <td>Siddharth Seth</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>stevel</td>
-          <td>Steve Loughran</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>0</td>
-      </tr>
-      <tr>
-          <td>subru</td>
-          <td>Subru Krishnan</td>
-          <td>Microsoft</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sunchao</td>
-          <td><a href="http://sunchao.github.io">Chao Sun</a></td>
-          <td>Apple</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>sunilg</td>
-          <td>Sunil Govindan</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>surendralilhore</td>
-          <td>Surendra Singh Lilhore</td>
-          <td>Microsoft</td>
-          <td>HDFS</td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>suresh</td>
-          <td><a href="http://people.apache.org/~suresh">Suresh Srinivas</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>swagle</td>
-          <td><a href="https://github.com/swagle">Siddharth Wagle</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>szegedim</td>
-          <td>Miklos Szegedi</td>
-          <td>Cloudera</td>
-          <td>YARN</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>szetszwo</td>
-          <td><a href="http://people.apache.org/~szetszwo">Tsz Wo (Nicholas) Sze</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>tanping</td>
-          <td><a href="http://people.apache.org/~tanping">Tanping Wang</a></td>
-          <td>Yahoo!</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>taoyang</td>
-          <td>Tao Yang</td>
-          <td>Alibaba</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>tasanuma</td>
-          <td><a href="http://people.apache.org/~tasanuma">Takanobu Asanuma</a></td>
-          <td>Yahoo! JAPAN</td>
-          <td></td>
-          <td>+9</td>
-      </tr>
-      <tr>
-          <td>taton</td>
-          <td><a href="http://people.apache.org/~taton">Christophe Taton</a></td>
-          <td>INRIA</td>
-          <td></td>
-          <td>+1</td>
-      </tr>
-      <tr>
-          <td>templedf</td>
-          <td>Daniel Templeton</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>tgraves</td>
-          <td>Thomas Graves</td>
-          <td>NVIDIA</td>
-          <td></td>
-          <td>-6</td>
-      </tr>
-      <tr>
-          <td>todd</td>
-          <td><a href="http://people.apache.org/~todd">Todd Lipcon</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>tomscut</td>
-          <td><a href="http://github.com/tomscut">Tao Li</a></td>
-          <td>BIGO</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>tomwhite</td>
-          <td><a href="http://www.lexemetech.com">Tom White</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>tucu</td>
-          <td>Alejandro Abdelnur</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>umamahesh</td>
-          <td><a href="https://people.apache.org/~umamahesh/umamahesh.html">Uma Maheswara Rao G</a></td>
-          <td>Intel</td>
-          <td>HDFS</td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>varunsaxena</td>
-          <td><a href="http://people.apache.org/~varunsaxena">Varun Saxena</a></td>
-          <td>LinkedIn</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>vinayakumarb</td>
-          <td><a href="http://people.apache.org/~vinayakumarb">Vinayakumar B</a></td>
-          <td>Google</td>
-          <td>HDFS</td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>vinodkv</td>
-          <td><a href="http://people.apache.org/~vinodkv">Vinod Kumar Vavilapalli</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>vivekratnavel</td>
-          <td><a href="https://github.com/vivekratnavel">Vivek Ratnavel Subramanian</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>vrushali</td>
-          <td><a href="http://people.apache.org/~vrushali">Vrushali Channapattan</a></td>
-          <td>Twitter</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>vvasudev</td>
-          <td>Varun Vasudev</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+5.5</td>
-      </tr>
-      <tr>
-          <td>waltersu4549</td>
-          <td>Walter Su</td>
-          <td></td>
-          <td>HDFS</td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>wang</td>
-          <td>Andrew Wang</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>wangda</td>
-          <td>Wangda Tan</td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>weichiu</td>
-          <td><a href="http://weichiu.com/about-wei-chiu/">Wei-Chiu Chuang</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>weiy</td>
-          <td>Wei Yan</td>
-          <td>Google</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>wheat9</td>
-          <td><a href="http://haohui.me">Haohui Mai</a></td>
-          <td>Uber</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>wilfreds</td>
-          <td><a href="https://github.com/wilfred-s">Wilfred Spiegelenburg</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+10</td>
-      </tr>
-      <tr>
-          <td>wwei</td>
-          <td><a href="https://yangwwei.github.io/">Weiwei Yang</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>xgong</td>
-          <td><a href="http://people.apache.org/~xgong">Xuan Gong</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>xiao</td>
-          <td>Xiao Chen</td>
-          <td>Netflix</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>xkrogen</td>
-          <td><a href="https://www.linkedin.com/in/xkrogen/">Erik Krogen</a></td>
-          <td>LinkedIn</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>xyao</td>
-          <td><a href="http://people.apache.org/~xyao">Xiaoyu Yao</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>yufei</td>
-          <td><a href="http://people.apache.org/~yufei">Yufei Gu</a></td>
-          <td>Apple</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>yjzhangal</td>
-          <td><a href="http://people.apache.org/~yjzhangal">Yongjun Zhang</a></td>
-          <td>Pinterest</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>yliu</td>
-          <td><a href="http://people.apache.org/~yliu">Yi Liu</a></td>
-          <td>Intel</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>yqlin</td>
-          <td><a href="https://github.com/linyiqun">Yiqun Lin</a></td>
-          <td>EBay</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>zanderxu</td>
-          <td><a href="https://github.com/ZanderXu">Zengqiang Xu</a></td>
-          <td>Shopee</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>zhangshuyan</td>
-          <td><a href="https://github.com/zhangshuyan0">Shuyan Zhang</a></td>
-          <td>Meituan</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>zhouquan</td>
-          <td><a href="https://github.com/yuanzac">Zac Zhou</a></td>
-          <td>Tencent</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>zhuqi</td>
-          <td><a href="https://github.com/zhuqi-lucas">Qi Zhu</a></td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>zhz</td>
-          <td><a href="http://zhe-thoughts.github.io/about/">Zhe Zhang</a></td>
-          <td>LinkedIn</td>
-          <td>HDFS</td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>zjshen</td>
-          <td><a href="http://people.apache.org/~zjshen">Zhijie Shen</a></td>
-          <td>Hortonworks</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>zshao</td>
-          <td><a href="http://people.apache.org/~zshao">Zheng Shao</a></td>
-          <td>Facebook</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-      <tr>
-          <td>ztang</td>
-          <td>Zhankun Tang</td>
-          <td>Cloudera</td>
-          <td></td>
-          <td>+8</td>
-      </tr>
-      <tr>
-          <td>zxu</td>
-          <td><a href="http://people.apache.org/~zxu">Zhihai Xu</a></td>
-          <td>Uber</td>
-          <td></td>
-          <td>-8</td>
-      </tr>
-  </tbody>
+<thead>
+<tr>
+<th>username</th>
+<th>name</th>
+<th>organization</th>
+<th>roles</th>
+<th>timezone</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>aajisaka</td>
+<td>Akira Ajisaka</td>
+<td>AWS</td>
+<td></td>
+<td>+9</td>
+</tr>
+<tr>
+<td>ab</td>
+<td>Andrzej Bialecki</td>
+<td>Getopt</td>
+<td></td>
+<td>+1</td>
+</tr>
+<tr>
+<td>abmodi</td>
+<td>Abhishek Modi</td>
+<td>Google</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>acmurthy</td>
+<td><a href="http://people.apache.org/~acmurthy">Arun C Murthy</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>adhoot</td>
+<td>Anubhav Dhoot</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>aengineer</td>
+<td>Anu Engineer</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ajay</td>
+<td>Ajay Kumar</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>amareshwari</td>
+<td><a href="http://people.apache.org/~amareshwari">Amareshwari Sriramadasu</a></td>
+<td>InMobi</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>amarrk</td>
+<td><a href="http://people.apache.org/~amarrk">Amar Ramesh Kamat</a></td>
+<td>Yahoo!</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>arp</td>
+<td><a href="http://people.apache.org/~arp">Arpit Agarwal</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>arpit</td>
+<td><a href="http://people.apache.org/~arpit">Arpit Gupta</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>asuresh</td>
+<td>Arun Suresh</td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>atm</td>
+<td><a href="http://people.apache.org/~atm">Aaron T. Myers</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>avijayan</td>
+<td><a href="https://github.com/avijayanhwx">Aravindan Vijayan</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>aw</td>
+<td>Allen Wittenauer</td>
+<td>Effective Machines</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ayushsaxena</td>
+<td>Ayush Saxena</td>
+<td>Cloudera</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>benoy</td>
+<td><a href="http://people.apache.org/~benoy">Benoy Antony</a></td>
+<td>eBay</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>bharat</td>
+<td>Bharat Viswanadham</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>bibinchundatt</td>
+<td>Bibin A Chundatt</td>
+<td>Microsoft</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>bikas</td>
+<td>Bikas Saha</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>billie</td>
+<td>Billie Rinaldi</td>
+<td>Cloudera</td>
+<td></td>
+<td>-5</td>
+</tr>
+<tr>
+<td>bobby</td>
+<td>Robert(Bobby) Evans</td>
+<td>NVIDIA</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>boryas</td>
+<td><a href="http://people.apache.org/~boryas">Boris Shkolnik</a></td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>botong</td>
+<td>Botong Huang</td>
+<td>Alibaba</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>brahma</td>
+<td>Brahma Reddy Battula</td>
+<td>Huawei</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>brandonli</td>
+<td>Brandon Li</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>bteke</td>
+<td><a href="https://github.com/brumi1024">Benjamin Teke</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+1</td>
+</tr>
+<tr>
+<td>busbey</td>
+<td>Sean Busbey</td>
+<td>Cloudera</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>cdouglas</td>
+<td>Chris Douglas</td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cliang</td>
+<td>Chen Liang</td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cmccabe</td>
+<td><a href="http://www.club.cc.cmu.edu/~cmccabe">Colin Patrick McCabe</a></td>
+<td>Cloudera</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cnauroth</td>
+<td><a href="https://github.com/cnauroth">Chris Nauroth</a></td>
+<td>Google</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cos</td>
+<td><a href="http://people.apache.org/~cos">Konstantin Boudnik</a></td>
+<td>WANdisco</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>csingh</td>
+<td>Chandni Singh</td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ctrezzo</td>
+<td>Chris Trezzo</td>
+<td>Twitter</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>curino</td>
+<td>Carlo Curino</td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>cutting</td>
+<td><a href="http://blog.lucene.com/">Doug Cutting</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>daryn</td>
+<td>Daryn Sharp</td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>ddas</td>
+<td><a href="http://people.apache.org/~ddas">Devaraj Das</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>devaraj</td>
+<td>Devaraj K</td>
+<td>Intel</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>dhruba</td>
+<td><a href="http://people.apache.org/~dhruba">Dhruba Borthakur</a></td>
+<td>Facebook</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>dineshc</td>
+<td><a href="https://www.linkedin.com/in/dineshchitlangia/">Dinesh Chitlangia</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-5</td>
+</tr>
+<tr>
+<td>dmollitor</td>
+<td><a href="https://www.linkedin.com/in/david-mollitor-a17b779/">David Mollitor</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-5</td>
+</tr>
+<tr>
+<td>drankye</td>
+<td><a href="http://people.apache.org/~drankye">Kai Zheng</a></td>
+<td>Intel</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>ebadger</td>
+<td>Eric Badger</td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>elek</td>
+<td><a href="https://github.com/elek">Márton Elek</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>+1</td>
+</tr>
+<tr>
+<td>eli</td>
+<td><a href="http://people.apache.org/~eli">Eli Collins</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>epayne</td>
+<td><a href="http://people.apache.org/~epayne">Eric Payne</a></td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>enis</td>
+<td><a href="http://people.apache.org/~enis">Enis Soztutar</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>eyang</td>
+<td><a href="http://people.apache.org/~eyang">Eric Yang</a></td>
+<td>IBM</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ferhui</td>
+<td>Hui Fei</td>
+<td>Tencent</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>gabota</td>
+<td><a href="https://github.com/bgaborg">Gabor Bota</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+1</td>
+</tr>
+<tr>
+<td>gaurava</td>
+<td><a href="https://github.com/GauthamBanasandra">Gautham Banasandra</a></td>
+<td>Microsoft</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>gera</td>
+<td><a href="https://github.com/gerashegalov">Gera Shegalov</a></td>
+<td>NVIDIA</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>gifuma</td>
+<td>Giovanni Matteo Fumarola</td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>gkesavan</td>
+<td><a href="http://people.apache.org/~gkesavan">Giridharan Kesavan</a></td>
+<td>Hortonworks</td>
+<td>RE</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>gtcarrera9</td>
+<td>Li Lu</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>hemanthboyina</td>
+<td><a href="https://github.com/hemanthboyina">Hemanth Boyina</a></td>
+<td>Huawei</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>hitesh</td>
+<td>Hitesh Shah</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>haibochen</td>
+<td>Haibo Chen</td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>hairong</td>
+<td><a href="http://people.apache.org/~hairong">Hairong Kuang</a></td>
+<td>Facebook</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>hanishakoneru</td>
+<td>Hanisha Koneru</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>harsh</td>
+<td><a href="http://harshj.com/">Harsh J</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>hexiaoqiao</td>
+<td><a href="http://hexiaoqiao.github.io">He Xiaoqiao</a></td>
+<td>Meituan</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>huhaiyang</td>
+<td><a href="https://github.com/haiyang1987">Haiyang Hu</a></td>
+<td>Shopee</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>inigoiri</td>
+<td>Íñigo Goiri</td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ivanmi</td>
+<td>Ivan Mitic</td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>iwasakims</td>
+<td>Masatake Iwasaki</td>
+<td>NTT DATA</td>
+<td></td>
+<td>+9</td>
+</tr>
+<tr>
+<td>jbrennan</td>
+<td><a href="https://github.com/jbrennan333">Jim Brennan</a></td>
+<td>NVIDIA</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>jeagles</td>
+<td><a href="http://people.apache.org/~jeagles">Jonathan Eagles</a></td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>jghoman</td>
+<td><a href="http://people.apache.org/~jghoman">Jakob Homan</a></td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jhung</td>
+<td>Jonathan Hung</td>
+<td>LinkedIn</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jianhe</td>
+<td><a href="http://people.apache.org/~jianhe">Jian He</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jing9</td>
+<td>Jing Zhao</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jitendra</td>
+<td><a href="http://people.apache.org/~jitendra">Jitendra Nath Pandey</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>jlowe</td>
+<td>Jason Lowe</td>
+<td>NVIDIA</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>johan</td>
+<td><a href="http://people.apache.org/~johan">Johan Oskarsson</a></td>
+<td>Twitter</td>
+<td></td>
+<td>0</td>
+</tr>
+<tr>
+<td>junping_du</td>
+<td>Junping Du</td>
+<td>Datastrato</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>jzhuge</td>
+<td>John Zhuge</td>
+<td>Netflix</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>kasha</td>
+<td><a href="http://people.apache.org/~kasha">Karthik Kambatla</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>kihwal</td>
+<td><a href="http://people.apache.org/~kihwal">Kihwal Lee</a></td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>kkaranasos</td>
+<td><a href="http://www.microsoft.com/en-us/research/people/kokarana">Konstantinos Karanasos</a></td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>knoguchi</td>
+<td><a href="http://people.apache.org/~knoguchi">Koji Noguchi</a></td>
+<td>Verizon Media</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>kzhang</td>
+<td>Kan Zhang</td>
+<td>IBM</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>lei</td>
+<td><a href="http://people.apache.org/~lei">Lei Xu</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>licheng</td>
+<td><a href="https://www.linkedin.com/in/licheng1990/">Li Cheng</a></td>
+<td>Tencent</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>liuml07</td>
+<td><a href="http://people.apache.org/~liuml07">Mingliang Liu</a></td>
+<td>Salesforce</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>liuxun</td>
+<td><a href="https://github.com/xunliu/">Xun Liu</a></td>
+<td>Tencent</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>ljain</td>
+<td><a href="https://github.com/lokeshj1703">Lokesh Jain</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>lohit</td>
+<td><a href="http://people.apache.org/~lohit">Lohit Vijayarenu</a></td>
+<td>Twitter</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>llu</td>
+<td><a href="http://people.apache.org/~llu">Luke Lu</a></td>
+<td>VMware</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>lmccay</td>
+<td><a href="http://people.apache.org/~lmccay">Larry McCay</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-5</td>
+</tr>
+<tr>
+<td>mackrorysd</td>
+<td>Sean Mackrory</td>
+<td>Cloudera</td>
+<td></td>
+<td>-7</td>
+</tr>
+<tr>
+<td>mahadev</td>
+<td>Mahadev Konar</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>manojpec</td>
+<td>Manoj Govindassamy</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>matei</td>
+<td><a href="http://www.cs.berkeley.edu/~matei">Matei Zaharia</a></td>
+<td>UC Berkeley</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>mattf</td>
+<td><a href="http://people.apache.org/~mattf">Matthew Foley</a></td>
+<td>Apple</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>mayank</td>
+<td><a href="http://people.apache.org/~mayank">Mayank Bansal</a></td>
+<td>uber</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>molkov</td>
+<td><a href="http://people.apache.org/~molkov">Dmytro Molkov</a></td>
+<td>Facebook</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>mukund</td>
+<td><a href="http://people.apache.org/~mukund">Mukund Madhugiri</a></td>
+<td>Yahoo!</td>
+<td>QA</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>mingma</td>
+<td>Ming Ma</td>
+<td>Twitter</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>msingh</td>
+<td>Mukul Kumar Singh</td>
+<td>Hortonworks</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>naganarasimha_gr</td>
+<td><a href="http://people.apache.org/~naganarasimha_gr/">Naganarasimha G R</a></td>
+<td>SCB</td>
+<td></td>
+<td>+8.0</td>
+</tr>
+<tr>
+<td>nanda</td>
+<td>Nanda kumar</td>
+<td>Hortonworks</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>nigel</td>
+<td><a href="http://people.apache.org/~nigel">Nigel Daley</a></td>
+<td>Pinterest</td>
+<td>QA</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>nroberts</td>
+<td>Nathan Roberts</td>
+<td>Verizon Media</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>omalley</td>
+<td><a href="http://people.apache.org/~omalley">Owen O'Malley</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ozawa</td>
+<td><a href="http://people.apache.org/~ozawa">Tsuyoshi Ozawa</a></td>
+<td>NTT</td>
+<td></td>
+<td>+9</td>
+</tr>
+<tr>
+<td>prabhujoseph</td>
+<td>Prabhu Joseph</td>
+<td>Microsoft</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>quapaw</td>
+<td><a href="https://github.com/9uapaw">Andras Gyori</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+1</td>
+</tr>
+<tr>
+<td>rakeshr</td>
+<td><a href="https://people.apache.org/~rakeshr">Rakesh Radhakrishnan</a></td>
+<td>Intel</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>rangadi</td>
+<td><a href="http://people.apache.org/~rangadi">Raghu Angadi</a></td>
+<td>Twitter</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ramya</td>
+<td><a href="http://people.apache.org/~ramya">Ramya Sunil</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>raviprak</td>
+<td><a href="http://people.apache.org/~raviprak">Ravi Prakash</a></td>
+<td>Altiscale, Inc.</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>rchiang</td>
+<td>Ray Chiang</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>rkanter</td>
+<td>Robert Kanter</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>rohithsharmaks</td>
+<td>Rohith Sharma K S</td>
+<td>Hortonworks</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>rvs</td>
+<td><a href="http://people.apache.org/~rvs">Roman Shaposhnik</a></td>
+<td>Pivotal</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sammichen</td>
+<td>Sammi Chen</td>
+<td>Tencent</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>schen</td>
+<td><a href="http://people.apache.org/~schen">Scott Chun-Yang Chen</a></td>
+<td>Facebook</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sharad</td>
+<td>Sharad Agarwal</td>
+<td>InMobi</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>shv</td>
+<td><a href="http://people.apache.org/~shv">Konstantin Shvachko</a></td>
+<td>LinkedIn</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sandy</td>
+<td><a href="http://people.apache.org/~sandy">Sandy Ryza</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>shashikant</td>
+<td>Shashikant Banerjee</td>
+<td>Cloudera</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>siyao</td>
+<td><a href="http://people.apache.org/~siyao">Siyao Meng</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sjlee</td>
+<td><a href="http://people.apache.org/~sjlee">Sangjin Lee</a></td>
+<td>PayPal</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sradia</td>
+<td><a href="http://people.apache.org/~sradia">Sanjay Radia</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sreekanth</td>
+<td>Sreekanth Ramakrishnan</td>
+<td>InMobi</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>sidharta</td>
+<td>Sidharta Seethana</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>simbadzina</td>
+<td><a href="https://github.com/simbadzina">Simbarashe Dzinamarira</a></td>
+<td>LinkedIn</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>slfan1989</td>
+<td>Shilun Fan</td>
+<td>DiDi</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>snemeth</td>
+<td><a href="https://github.com/szilard-nemeth">Szilard Nemeth</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+1</td>
+</tr>
+<tr>
+<td>sseth</td>
+<td>Siddharth Seth</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>stevel</td>
+<td>Steve Loughran</td>
+<td>Cloudera</td>
+<td></td>
+<td>0</td>
+</tr>
+<tr>
+<td>subru</td>
+<td>Subru Krishnan</td>
+<td>Microsoft</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sunchao</td>
+<td><a href="http://sunchao.github.io">Chao Sun</a></td>
+<td>Apple</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>sunilg</td>
+<td>Sunil Govindan</td>
+<td>Cloudera</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>surendralilhore</td>
+<td>Surendra Singh Lilhore</td>
+<td>Microsoft</td>
+<td>HDFS</td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>suresh</td>
+<td><a href="http://people.apache.org/~suresh">Suresh Srinivas</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>swagle</td>
+<td><a href="https://github.com/swagle">Siddharth Wagle</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>szegedim</td>
+<td>Miklos Szegedi</td>
+<td>Cloudera</td>
+<td>YARN</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>szetszwo</td>
+<td><a href="http://people.apache.org/~szetszwo">Tsz Wo (Nicholas) Sze</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>tanping</td>
+<td><a href="http://people.apache.org/~tanping">Tanping Wang</a></td>
+<td>Yahoo!</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>taoyang</td>
+<td>Tao Yang</td>
+<td>Alibaba</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>tasanuma</td>
+<td><a href="http://people.apache.org/~tasanuma">Takanobu Asanuma</a></td>
+<td>Yahoo! JAPAN</td>
+<td></td>
+<td>+9</td>
+</tr>
+<tr>
+<td>taton</td>
+<td><a href="http://people.apache.org/~taton">Christophe Taton</a></td>
+<td>INRIA</td>
+<td></td>
+<td>+1</td>
+</tr>
+<tr>
+<td>templedf</td>
+<td>Daniel Templeton</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>tgraves</td>
+<td>Thomas Graves</td>
+<td>NVIDIA</td>
+<td></td>
+<td>-6</td>
+</tr>
+<tr>
+<td>todd</td>
+<td><a href="http://people.apache.org/~todd">Todd Lipcon</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>tomscut</td>
+<td><a href="http://github.com/tomscut">Tao Li</a></td>
+<td>BIGO</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>tomwhite</td>
+<td><a href="http://www.lexemetech.com">Tom White</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>tucu</td>
+<td>Alejandro Abdelnur</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>umamahesh</td>
+<td><a href="https://people.apache.org/~umamahesh/umamahesh.html">Uma Maheswara Rao G</a></td>
+<td>Intel</td>
+<td>HDFS</td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>varunsaxena</td>
+<td><a href="http://people.apache.org/~varunsaxena">Varun Saxena</a></td>
+<td>LinkedIn</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>vinayakumarb</td>
+<td><a href="http://people.apache.org/~vinayakumarb">Vinayakumar B</a></td>
+<td>Google</td>
+<td>HDFS</td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>vinodkv</td>
+<td><a href="http://people.apache.org/~vinodkv">Vinod Kumar Vavilapalli</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>vivekratnavel</td>
+<td><a href="https://github.com/vivekratnavel">Vivek Ratnavel Subramanian</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>vrushali</td>
+<td><a href="http://people.apache.org/~vrushali">Vrushali Channapattan</a></td>
+<td>Twitter</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>vvasudev</td>
+<td>Varun Vasudev</td>
+<td>Hortonworks</td>
+<td></td>
+<td>+5.5</td>
+</tr>
+<tr>
+<td>waltersu4549</td>
+<td>Walter Su</td>
+<td></td>
+<td>HDFS</td>
+<td>+8</td>
+</tr>
+<tr>
+<td>wang</td>
+<td>Andrew Wang</td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>wangda</td>
+<td>Wangda Tan</td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>weichiu</td>
+<td><a href="http://weichiu.com/about-wei-chiu/">Wei-Chiu Chuang</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>weiy</td>
+<td>Wei Yan</td>
+<td>Google</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>wheat9</td>
+<td><a href="http://haohui.me">Haohui Mai</a></td>
+<td>Uber</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>wilfreds</td>
+<td><a href="https://github.com/wilfred-s">Wilfred Spiegelenburg</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+10</td>
+</tr>
+<tr>
+<td>wwei</td>
+<td><a href="https://yangwwei.github.io/">Weiwei Yang</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>xgong</td>
+<td><a href="http://people.apache.org/~xgong">Xuan Gong</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>xiao</td>
+<td>Xiao Chen</td>
+<td>Netflix</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>xkrogen</td>
+<td><a href="https://www.linkedin.com/in/xkrogen/">Erik Krogen</a></td>
+<td>LinkedIn</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>xyao</td>
+<td><a href="http://people.apache.org/~xyao">Xiaoyu Yao</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>yufei</td>
+<td><a href="http://people.apache.org/~yufei">Yufei Gu</a></td>
+<td>Apple</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>yjzhangal</td>
+<td><a href="http://people.apache.org/~yjzhangal">Yongjun Zhang</a></td>
+<td>Pinterest</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>yliu</td>
+<td><a href="http://people.apache.org/~yliu">Yi Liu</a></td>
+<td>Intel</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>yqlin</td>
+<td><a href="https://github.com/linyiqun">Yiqun Lin</a></td>
+<td>EBay</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>zanderxu</td>
+<td><a href="https://github.com/ZanderXu">Zengqiang Xu</a></td>
+<td>Shopee</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>zhangshuyan</td>
+<td><a href="https://github.com/zhangshuyan0">Shuyan Zhang</a></td>
+<td>Meituan</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>zhouquan</td>
+<td><a href="https://github.com/yuanzac">Zac Zhou</a></td>
+<td>Tencent</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>zhuqi</td>
+<td><a href="https://github.com/zhuqi-lucas">Qi Zhu</a></td>
+<td>Cloudera</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>zhz</td>
+<td><a href="http://zhe-thoughts.github.io/about/">Zhe Zhang</a></td>
+<td>LinkedIn</td>
+<td>HDFS</td>
+<td>-8</td>
+</tr>
+<tr>
+<td>zjshen</td>
+<td><a href="http://people.apache.org/~zjshen">Zhijie Shen</a></td>
+<td>Hortonworks</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>zshao</td>
+<td><a href="http://people.apache.org/~zshao">Zheng Shao</a></td>
+<td>Facebook</td>
+<td></td>
+<td>-8</td>
+</tr>
+<tr>
+<td>ztang</td>
+<td>Zhankun Tang</td>
+<td>Cloudera</td>
+<td></td>
+<td>+8</td>
+</tr>
+<tr>
+<td>zxu</td>
+<td><a href="http://people.apache.org/~zxu">Zhihai Xu</a></td>
+<td>Uber</td>
+<td></td>
+<td>-8</td>
+</tr>
+</tbody>
 </table>
 <h2 id="emeritus-hadoop-committers">Emeritus Hadoop Committers</h2>
 <p>Hadoop committers who are no longer active include:</p>
@@ -2255,7 +2258,7 @@ order):</p>
   <p>Apache Hadoop, Hadoop, Apache, the Apache feather logo,
     and the Apache Hadoop project logo are either registered trademarks or trademarks of the Apache Software Foundation
      in the United States and other countries</p>
-  <p>Copyright © 2006-2024 The Apache Software Foundation</p>
+  <p>Copyright © 2006-2025 The Apache Software Foundation</p>
   <p><a href="/privacy_policy.html">Privacy policy</a></p>
   </div>
   <div class="col-md-6">
@@ -2266,12 +2269,24 @@ order):</p>
     
     
     <script src="/js/jquery.min.js"></script>
-    <script>window.jQuery || document.write('\x3Cscript src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
     <script src="/js/bootstrap.min.js"></script>
     <script>
     $(function() { $('table').addClass('table table-striped'); })
     </script>
 
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+	(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+	m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	ga('create', 'UA-7453027-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
 </body>
 </html>
 

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -37,11 +37,4 @@
           {{ end }}
        {{end}}
      </ul>
-	  <ul class="nav navbar-nav navbar-right">
-      <li>
-       <a href="https://www.apache.org/">Apache Software Foundation <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span></a>
-      </li>
-
-
-     </ul>
    </div><!--/.nav-collapse -->


### PR DESCRIPTION
Fix issue about 'Apache Project Website Checks' shows at https://whimsy.apache.org/site/project/hadoop
changelist:
1. navigation
<img width="1462" alt="image" src="https://github.com/user-attachments/assets/2d9fecdd-9b65-4ff8-8e9c-6ae2dcd93b34" />
2. Copyright year to 2025.
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/3418c4ee-384d-4246-bcf9-9e5aa8dc1679" />
3. Other diff seems from hugo version diff and auto generate.