### PR TITLE
HADOOP-19459. Addendum: Comply with ASF website policy.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -100,7 +100,7 @@ publishDir = "content"
 
 [[menu.main]]
    name = "Event"
-   url = "https://events.apache.org"
+   url = "https://www.apache.org/events/current-event.html"
    parent = "apache"
 
 [[menu.main]]


### PR DESCRIPTION
Addendum: fix `Event` link to the formal target reported by Infra: https://whimsy.apache.org/site/project/hadoop