### PR TITLE
HADOOP-19459. Addendum: Comply with ASF website policy.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -100,7 +100,7 @@ publishDir = "content"
 
 [[menu.main]]
    name = "Event"
-   url = "https://events.apache.org"
+   url = "https://www.apache.org/events/current-event.html"
    parent = "apache"
 
 [[menu.main]]

--- a/content/bylaws.html
+++ b/content/bylaws.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/categories.html
+++ b/content/categories.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/committer_criteria.html
+++ b/content/committer_criteria.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/cve_list.html
+++ b/content/cve_list.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/description.html
+++ b/content/description.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/index.html
+++ b/content/index.html
@@ -124,7 +124,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/issue_tracking.html
+++ b/content/issue_tracking.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/mailing_lists.html
+++ b/content/mailing_lists.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/modules.html
+++ b/content/modules.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news.html
+++ b/content/news.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2008-07-xx-terabyte-sort.html
+++ b/content/news/2008-07-xx-terabyte-sort.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2008-11-xx-apachecon.html
+++ b/content/news/2008-11-xx-apachecon.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2009-03-xx-apachecon-eu.html
+++ b/content/news/2009-03-xx-apachecon-eu.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2009-07-xx-subprojects.html
+++ b/content/news/2009-07-xx-subprojects.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2010-05-xx-avro-hbase.html
+++ b/content/news/2010-05-xx-avro-hbase.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2010-10-xx-hive-pig.html
+++ b/content/news/2010-10-xx-hive-pig.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2011-01-xx-zookeeper.html
+++ b/content/news/2011-01-xx-zookeeper.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2011-03-xx-award.html
+++ b/content/news/2011-03-xx-award.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2018-10-01-ozone-0.2.1-alpha.html
+++ b/content/news/2018-10-01-ozone-0.2.1-alpha.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2018-11-22-ozone-0.3.0-alpha.html
+++ b/content/news/2018-11-22-ozone-0.3.0-alpha.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2019-05-07-ozone-0.4.0-alpha.html
+++ b/content/news/2019-05-07-ozone-0.4.0-alpha.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2019-10-13-ozone-0.4.1-alpha.html
+++ b/content/news/2019-10-13-ozone-0.4.1-alpha.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2020-03-24-ozone-0.5.0-beta.html
+++ b/content/news/2020-03-24-ozone-0.5.0-beta.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2020-09-02-ozone-1.0.0.html
+++ b/content/news/2020-09-02-ozone-1.0.0.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2021-04-17-ozone-1.1.0.html
+++ b/content/news/2021-04-17-ozone-1.1.0.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/2021-12-17-log4shell.html
+++ b/content/news/2021-12-17-log4shell.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/news/page/2.html
+++ b/content/news/page/2.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/privacy_policy.html
+++ b/content/privacy_policy.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/related.html
+++ b/content/related.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release.html
+++ b/content/release.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.14.1.html
+++ b/content/release/0.14.1.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.14.3.html
+++ b/content/release/0.14.3.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.14.4.html
+++ b/content/release/0.14.4.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.15.0.html
+++ b/content/release/0.15.0.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.15.1.html
+++ b/content/release/0.15.1.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.15.2.html
+++ b/content/release/0.15.2.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.15.3.html
+++ b/content/release/0.15.3.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.16.0.html
+++ b/content/release/0.16.0.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.16.1.html
+++ b/content/release/0.16.1.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.16.2.html
+++ b/content/release/0.16.2.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.16.3.html
+++ b/content/release/0.16.3.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.16.4.html
+++ b/content/release/0.16.4.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.17.0.html
+++ b/content/release/0.17.0.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.17.1.html
+++ b/content/release/0.17.1.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.17.2.html
+++ b/content/release/0.17.2.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.18.0.html
+++ b/content/release/0.18.0.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.18.1.html
+++ b/content/release/0.18.1.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.18.2.html
+++ b/content/release/0.18.2.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.18.3.html
+++ b/content/release/0.18.3.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.19.0.html
+++ b/content/release/0.19.0.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.19.1.html
+++ b/content/release/0.19.1.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.19.2.html
+++ b/content/release/0.19.2.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.20.0.html
+++ b/content/release/0.20.0.html
@@ -134,7 +134,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.20.1.html
+++ b/content/release/0.20.1.html
@@ -134,7 +134,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.20.2.html
+++ b/content/release/0.20.2.html
@@ -134,7 +134,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.20.203.0.html
+++ b/content/release/0.20.203.0.html
@@ -136,7 +136,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.20.204.0.html
+++ b/content/release/0.20.204.0.html
@@ -136,7 +136,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.20.205.0.html
+++ b/content/release/0.20.205.0.html
@@ -136,7 +136,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.21.0.html
+++ b/content/release/0.21.0.html
@@ -132,7 +132,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.22.0.html
+++ b/content/release/0.22.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.0.html
+++ b/content/release/0.23.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.1.html
+++ b/content/release/0.23.1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.10.html
+++ b/content/release/0.23.10.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.11.html
+++ b/content/release/0.23.11.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.3.html
+++ b/content/release/0.23.3.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.4.html
+++ b/content/release/0.23.4.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.5.html
+++ b/content/release/0.23.5.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.6.html
+++ b/content/release/0.23.6.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.7.html
+++ b/content/release/0.23.7.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.8.html
+++ b/content/release/0.23.8.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/0.23.9.html
+++ b/content/release/0.23.9.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.0.0.html
+++ b/content/release/1.0.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.0.1.html
+++ b/content/release/1.0.1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.0.2.html
+++ b/content/release/1.0.2.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.0.3.html
+++ b/content/release/1.0.3.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.0.4.html
+++ b/content/release/1.0.4.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.1.0.html
+++ b/content/release/1.1.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.1.1.html
+++ b/content/release/1.1.1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.1.2.html
+++ b/content/release/1.1.2.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.2.0.html
+++ b/content/release/1.2.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/1.2.1.html
+++ b/content/release/1.2.1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.0.0-alpha.html
+++ b/content/release/2.0.0-alpha.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.0.1-alpha.html
+++ b/content/release/2.0.1-alpha.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.0.2-alpha.html
+++ b/content/release/2.0.2-alpha.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.0.3-alpha.html
+++ b/content/release/2.0.3-alpha.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.0.4-alpha.html
+++ b/content/release/2.0.4-alpha.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.0.5-alpha.html
+++ b/content/release/2.0.5-alpha.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.0.6-alpha.html
+++ b/content/release/2.0.6-alpha.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.1.0-beta.html
+++ b/content/release/2.1.0-beta.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.1.1-beta.html
+++ b/content/release/2.1.1-beta.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.10.0.html
+++ b/content/release/2.10.0.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.10.1.html
+++ b/content/release/2.10.1.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.10.2.html
+++ b/content/release/2.10.2.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.2.0.html
+++ b/content/release/2.2.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.3.0.html
+++ b/content/release/2.3.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.4.0.html
+++ b/content/release/2.4.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.4.1.html
+++ b/content/release/2.4.1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.5.0.html
+++ b/content/release/2.5.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.5.1.html
+++ b/content/release/2.5.1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.5.2.html
+++ b/content/release/2.5.2.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.6.0.html
+++ b/content/release/2.6.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.6.1.html
+++ b/content/release/2.6.1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.6.2.html
+++ b/content/release/2.6.2.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.6.3.html
+++ b/content/release/2.6.3.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.6.4.html
+++ b/content/release/2.6.4.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.6.5.html
+++ b/content/release/2.6.5.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.7.0.html
+++ b/content/release/2.7.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.7.1.html
+++ b/content/release/2.7.1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.7.2.html
+++ b/content/release/2.7.2.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.7.3.html
+++ b/content/release/2.7.3.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.7.4.html
+++ b/content/release/2.7.4.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.7.5.html
+++ b/content/release/2.7.5.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.7.6.html
+++ b/content/release/2.7.6.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.7.7.html
+++ b/content/release/2.7.7.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.8.0.html
+++ b/content/release/2.8.0.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.8.1.html
+++ b/content/release/2.8.1.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.8.2.html
+++ b/content/release/2.8.2.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.8.3.html
+++ b/content/release/2.8.3.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.8.4.html
+++ b/content/release/2.8.4.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.8.5.html
+++ b/content/release/2.8.5.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.9.0.html
+++ b/content/release/2.9.0.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.9.1.html
+++ b/content/release/2.9.1.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/2.9.2.html
+++ b/content/release/2.9.2.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.0.0-alpha1.html
+++ b/content/release/3.0.0-alpha1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.0.0-alpha2.html
+++ b/content/release/3.0.0-alpha2.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.0.0-alpha4.html
+++ b/content/release/3.0.0-alpha4.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.0.0-beta1.html
+++ b/content/release/3.0.0-beta1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.0.0.html
+++ b/content/release/3.0.0.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.0.1.html
+++ b/content/release/3.0.1.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.0.2.html
+++ b/content/release/3.0.2.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.0.3.html
+++ b/content/release/3.0.3.html
@@ -135,7 +135,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.1.0.html
+++ b/content/release/3.1.0.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.1.1.html
+++ b/content/release/3.1.1.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.1.2.html
+++ b/content/release/3.1.2.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.1.3.html
+++ b/content/release/3.1.3.html
@@ -139,7 +139,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.1.4.html
+++ b/content/release/3.1.4.html
@@ -139,7 +139,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.2.0.html
+++ b/content/release/3.2.0.html
@@ -137,7 +137,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.2.1.html
+++ b/content/release/3.2.1.html
@@ -139,7 +139,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.2.2.html
+++ b/content/release/3.2.2.html
@@ -139,7 +139,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.2.3.html
+++ b/content/release/3.2.3.html
@@ -139,7 +139,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.2.4.html
+++ b/content/release/3.2.4.html
@@ -139,7 +139,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.3.0.html
+++ b/content/release/3.3.0.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.3.1.html
+++ b/content/release/3.3.1.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.3.2.html
+++ b/content/release/3.3.2.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.3.3.html
+++ b/content/release/3.3.3.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.3.4.html
+++ b/content/release/3.3.4.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.3.5.html
+++ b/content/release/3.3.5.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.3.6.html
+++ b/content/release/3.3.6.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.4.0.html
+++ b/content/release/3.4.0.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/3.4.1.html
+++ b/content/release/3.4.1.html
@@ -138,7 +138,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/10.html
+++ b/content/release/page/10.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/11.html
+++ b/content/release/page/11.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/12.html
+++ b/content/release/page/12.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/2.html
+++ b/content/release/page/2.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/3.html
+++ b/content/release/page/3.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/4.html
+++ b/content/release/page/4.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/5.html
+++ b/content/release/page/5.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/6.html
+++ b/content/release/page/6.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/7.html
+++ b/content/release/page/7.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/8.html
+++ b/content/release/page/8.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/release/page/9.html
+++ b/content/release/page/9.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/releases.html
+++ b/content/releases.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/tags.html
+++ b/content/tags.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/version_control.html
+++ b/content/version_control.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/versioning.html
+++ b/content/versioning.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                

--- a/content/who.html
+++ b/content/who.html
@@ -123,7 +123,7 @@
                
                   <li ><a href="https://www.cafepress.com/hadoop">Buy Stuff</a></li>
                
-                  <li ><a href="https://events.apache.org">Event</a></li>
+                  <li ><a href="https://www.apache.org/events/current-event.html">Event</a></li>
                
                   <li ><a href="https://www.apache.org/licenses">License</a></li>
                


### PR DESCRIPTION
Missing `hugo` to generate content after change `config.toml` at last commit (https://github.com/apache/hadoop-site/pull/65). 