### PR TITLE
Add Hualong Zhang to Committer List

### DIFF
--- a/content/who.html
+++ b/content/who.html
@@ -2221,6 +2221,13 @@ order):</p>
           <td>+8</td>
       </tr>
       <tr>
+          <td>zhtttylz</td>
+          <td><a href="https://github.com/zhtttylz">Hualong Zhang</a></td>
+          <td>DiDi</td>
+          <td></td>
+          <td>+8</td>
+      </tr>
+      <tr>
           <td>zhuqi</td>
           <td><a href="https://github.com/zhuqi-lucas">Qi Zhu</a></td>
           <td>Cloudera</td>

--- a/src/who.md
+++ b/src/who.md
@@ -336,6 +336,7 @@ yqlin               |[Yiqun Lin](https://github.com/linyiqun)                   
 zanderxu            |[Zengqiang Xu](https://github.com/ZanderXu)                                         |Shopee                          |        |+8
 zhangshuyan         |[Shuyan Zhang](https://github.com/zhangshuyan0)                                     |Meituan                         |        |+8
 zhouquan            |[Zac Zhou](https://github.com/yuanzac)                                              |Tencent                         |        |+8
+zhtttylz            |[Hualong Zhang](https://github.com/zhtttylz)                                        |DiDi                            |        |+8
 zhuqi               |[Qi Zhu](https://github.com/zhuqi-lucas)                                            |Cloudera                        |        |+8
 zhz                 |[Zhe Zhang](http://zhe-thoughts.github.io/about/)                                   |LinkedIn                        |HDFS    |-8
 zjshen              |[Zhijie Shen](http://people.apache.org/~zjshen)                                     |Hortonworks                     |        |-8


### PR DESCRIPTION
Add Hualong Zhang (zhtttylz) to the Hadoop committer list and update the generated who.html page.